### PR TITLE
Fix compiler errors on compilers other than msvc

### DIFF
--- a/examples/array_multiplication/CMakeLists.txt
+++ b/examples/array_multiplication/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.17.0)
-project(kompute_godot VERSION 0.1.0)
+project(kompute_array_mult VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 14)
 
@@ -13,15 +13,10 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE=1 ${KOMPUTE_EX
 find_package(kompute REQUIRED)
 find_package(Vulkan REQUIRED)
 
-add_executable(kompute_godot
+add_executable(kompute_array_mult
     src/Main.cpp)
 
-target_link_libraries(kompute_godot
+target_link_libraries(kompute_array_mult
     kompute::kompute
     Vulkan::Vulkan
 )
-
-target_link_libraries(kompute_godot
-    "lib/godot.windows.tools.64.lib"
-)
-

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -1195,7 +1195,7 @@ OpAlgoBase<tX, tY, tZ>::init()
 
     SPDLOG_DEBUG("Kompute OpAlgoBase fetching spirv data");
 
-    std::vector<char>& shaderFileData = this->fetchSpirvBinaryData();
+    std::vector<char> shaderFileData = this->fetchSpirvBinaryData();
 
     SPDLOG_DEBUG("Kompute OpAlgoBase Initialising algorithm component");
 
@@ -1427,7 +1427,7 @@ OpAlgoLhsRhsOut<tX, tY, tZ>::init()
 
     SPDLOG_DEBUG("Kompute OpAlgoLhsRhsOut fetching spirv data");
 
-    std::vector<char>& shaderFileData = this->fetchSpirvBinaryData();
+    std::vector<char> shaderFileData = this->fetchSpirvBinaryData();
 
     SPDLOG_DEBUG("Kompute OpAlgoLhsRhsOut Initialising algorithm component");
 

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -792,7 +792,7 @@ class Manager
      */
     template<typename T, typename... TArgs>
     void evalOp(std::vector<std::shared_ptr<Tensor>> tensors,
-                std::string sequenceName = KP_DEFAULT_SESSION,
+                std::string sequenceName,
                 TArgs&&... params)
     {
         SPDLOG_DEBUG("Kompute Manager evalOp triggered");

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -101,7 +101,6 @@ class Manager
      * sequences.
      *
      * @param tensors The tensors to be used in the operation recorded
-     * @param sequenceName The name of the sequence to be retrieved or created
      * @param TArgs Template parameters that will be used to initialise
      * Operation to allow for extensible configurations on initialisation
      */

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -73,7 +73,7 @@ class Manager
      */
     template<typename T, typename... TArgs>
     void evalOp(std::vector<std::shared_ptr<Tensor>> tensors,
-                std::string sequenceName = KP_DEFAULT_SESSION,
+                std::string sequenceName,
                 TArgs&&... params)
     {
         SPDLOG_DEBUG("Kompute Manager evalOp triggered");

--- a/src/include/kompute/operations/OpAlgoBase.hpp
+++ b/src/include/kompute/operations/OpAlgoBase.hpp
@@ -236,7 +236,7 @@ OpAlgoBase<tX, tY, tZ>::init()
 
     SPDLOG_DEBUG("Kompute OpAlgoBase fetching spirv data");
 
-    std::vector<char>& shaderFileData = this->fetchSpirvBinaryData();
+    std::vector<char> shaderFileData = this->fetchSpirvBinaryData();
 
     SPDLOG_DEBUG("Kompute OpAlgoBase Initialising algorithm component");
 

--- a/src/include/kompute/operations/OpAlgoLhsRhsOut.hpp
+++ b/src/include/kompute/operations/OpAlgoLhsRhsOut.hpp
@@ -162,7 +162,7 @@ OpAlgoLhsRhsOut<tX, tY, tZ>::init()
 
     SPDLOG_DEBUG("Kompute OpAlgoLhsRhsOut fetching spirv data");
 
-    std::vector<char>& shaderFileData = this->fetchSpirvBinaryData();
+    std::vector<char> shaderFileData = this->fetchSpirvBinaryData();
 
     SPDLOG_DEBUG("Kompute OpAlgoLhsRhsOut Initialising algorithm component");
 

--- a/test/TestManager.cpp
+++ b/test/TestManager.cpp
@@ -8,18 +8,18 @@ TEST(TestManager, EndToEndOpMultFlow)
     kp::Manager mgr;
 
     std::shared_ptr<kp::Tensor> tensorLHS{ new kp::Tensor({ 0, 1, 2 }) };
-    mgr.evalOp<kp::OpTensorCreate>({ tensorLHS });
+    mgr.evalOpDefault<kp::OpTensorCreate>({ tensorLHS });
 
     std::shared_ptr<kp::Tensor> tensorRHS{ new kp::Tensor({ 2, 4, 6 }) };
-    mgr.evalOp<kp::OpTensorCreate>({ tensorRHS });
+    mgr.evalOpDefault<kp::OpTensorCreate>({ tensorRHS });
 
     std::shared_ptr<kp::Tensor> tensorOutput{ new kp::Tensor({ 0, 0, 0 }) };
 
-    mgr.evalOp<kp::OpTensorCreate>({ tensorOutput });
+    mgr.evalOpDefault<kp::OpTensorCreate>({ tensorOutput });
 
-    mgr.evalOp<kp::OpMult<>>({ tensorLHS, tensorRHS, tensorOutput });
+    mgr.evalOpDefault<kp::OpMult<>>({ tensorLHS, tensorRHS, tensorOutput });
 
-    mgr.evalOp<kp::OpTensorSyncLocal>({ tensorOutput });
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensorOutput });
 
     EXPECT_EQ(tensorOutput->data(), std::vector<float>({ 0, 4, 12 }));
 }


### PR DESCRIPTION
The removal of the references to temporary variables fixed the compilation of the array_multiplication example.

The removal of the default argument of `kp::Manager::evalOp` was necessary to use `kp::Manager::evalOpDefault(std::vector<std::shared_ptr<Tensor>>, const char*)`