### PR TITLE
Adding Asynchronous Processing Capabilities with Multiple Queue Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,11 @@ int main() {
     // You can allow Kompute to create the Vulkan components, or pass your existing ones
     kp::Manager mgr; // Selects device 0 unless explicitly requested
 
-    // For synchronous steps we must already have a sequence created
-    mgr.createManagedSequence("async");
-
     // Creates tensor an initializes GPU memory (below we show more granularity)
     auto tensor = std::make_shared<kp::Tensor>(kp::Tensor(std::vector<float>(10, 0.0)));
 
     // Create tensors data explicitly in GPU with an operation
-    mgr.evalOpAsync<kp::OpTensorCreate>({ tensor }, "async");
+    mgr.evalOpAsyncDefault<kp::OpTensorCreate>({ tensor });
 
     // Define your shader as a string (using string literals for simplicity)
     // (You can also pass the raw compiled bytes, or even path to file)
@@ -218,25 +215,24 @@ int main() {
     )");
 
     // We can now await for the previous submitted command
-    // The second parameter can be the amount of time to wait
+    // The first parameter can be the amount of time to wait
     // The time provided is in nanoseconds
-    mgr.evalOpAwait("async", 10000);
+    mgr.evalOpAwaitDefault(10000);
 
     // Run Async Kompute operation on the parameters provided
-    mgr.evalOpAsync<kp::OpAlgoBase<>>(
+    mgr.evalOpAsyncDefault<kp::OpAlgoBase<>>(
         { tensor }, 
-        "async",
         std::vector<char>(shader.begin(), shader.end()));
 
     // Here we can do other work
 
     // When we're ready we can wait 
     // The default wait time is UINT64_MAX
-    mgr.evalOpAwait("async")
+    mgr.evalOpAwaitDefault()
 
     // Sync the GPU memory back to the local tensor
     // We can still run synchronous jobs in our created sequence
-    mgr.evalOp<kp::OpTensorSyncLocal>({ tensor }, "async");
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensor });
 
     // Prints the output: B: { 100000000, ... }
     std::cout << fmt::format("B: {}", 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@
 
 <h4>Blazing fast, lightweight, mobile-enabled, and optimized for advanced GPU processing usecases.</h4>
 
-🔋 [Documentation](https://ethicalml.github.io/vulkan-kompute/) 💻 [Blog Post](https://medium.com/@AxSaucedo/machine-learning-and-data-processing-in-the-gpu-with-vulkan-kompute-c9350e5e5d3a) ⌨ [Examples](https://github.com/EthicalML/vulkan-kompute#your-first-kompute) 💾
+🔋 [Documentation](https://kompute.cc) 💻 [Blog Post](https://medium.com/@AxSaucedo/machine-learning-and-data-processing-in-the-gpu-with-vulkan-kompute-c9350e5e5d3a) ⌨ [Examples](#more-examples) 💾
 
 
 ## Principles & Features
 
 * [Single header](single_include/kompute/Kompute.hpp) library for simple import to your project
-* [Documentation](https://ethicalml.github.io/vulkan-kompute/) leveraging doxygen and sphinx 
+* [Documentation](https://kompute.cc) leveraging doxygen and sphinx 
 * BYOV: Bring-your-own-Vulkan design to play nice with existing Vulkan applications
 * Non-Vulkan core naming conventions to disambiguate Vulkan vs Kompute components
 * Fast development cycles with shader tooling, but robust static shader binary bundles for prod
@@ -51,7 +51,7 @@ This project is built using cmake, providing a simple way to integrate as static
 
 #### Your First Kompute
 
-Pass compute shader data in glsl/hlsl text or compiled SPIR-V format (or as path to the file) - [view more examples](#more-examples).
+Pass compute shader data in glsl/hlsl text or compiled SPIR-V format (or as path to the file). View [more examples](#simple-examples).
 
 ```c++
 int main() {
@@ -103,7 +103,7 @@ This project started after seeing that a lot of new and renowned ML & DL project
 
 The Vulkan SDK offers a great low level interface that enables for highly specialized optimizations - however it comes at a cost of highly verbose code which requires 500-2000 lines of code to even begin writing application code. This has resulted in each of these projects having to implement the same baseline to abstract the non-compute related features of Vulkan, although it's not always the case, this can result in slower development cycles, and opportunities for bugs to be introduced.
 
-We are currently developing Vulkan Kompute not to hide the Vulkan SDK interface (as it's incredibly well designed) but to augment it with a direct focus on Vulkan's GPU computing capabilities. [This article](https://medium.com/swlh/machine-learning-and-data-processing-in-the-gpu-with-vulkan-kompute-c9350e5e5d3a) provides a high level overview of the motivations of Kompute, together with a set of hands on examples that introduce both GPU computing as well as the core Vulkan Kompute architecture.
+We are currently developing Vulkan Kompute not to hide the Vulkan SDK interface (as it's incredibly well designed) but to augment it with a direct focus on Vulkan's GPU computing capabilities. [This article](https://towardsdatascience.com/machine-learning-and-data-processing-in-the-gpu-with-vulkan-kompute-c9350e5e5d3a) provides a high level overview of the motivations of Kompute, together with a set of hands on examples that introduce both GPU computing as well as the core Vulkan Kompute architecture.
 
 ## More examples
 
@@ -111,7 +111,7 @@ We are currently developing Vulkan Kompute not to hide the Vulkan SDK interface 
 
 * [Pass shader as raw string](#your-first-kompute)
 * [Create your custom Kompute Operations](#your-custom-kompute-operation)
-* [Record batch commands with a Kompute Sequence](#record-batch-commands-with-a-kompute-sequence)
+* [Record batch commands with a Kompute Sequence](#record-batch-commands)
 
 ### End-to-end examples
 
@@ -121,7 +121,7 @@ We are currently developing Vulkan Kompute not to hide the Vulkan SDK interface 
 
 ### Your Custom Kompute Operation
 
-Build your own pre-compiled operations for domain specific workflows.
+Build your own pre-compiled operations for domain specific workflows. Back to [more examples](#simple-examples)
 
 We also provide tools that allow you to [convert shaders into C++ headers](https://github.com/EthicalML/vulkan-kompute/blob/master/scripts/convert_shaders.py#L40).
 
@@ -164,9 +164,9 @@ int main() {
 }
 ```
 
-#### Record batch commands with a Kompute Sequence
+#### Record batch commands
 
-Record commands in a single submit by using a Sequence to send in batch to GPU.
+Record commands in a single submit by using a Sequence to send in batch to GPU. Back to [more examples](#simple-examples)
 
 ```c++
 int main() {
@@ -213,13 +213,6 @@ int main() {
     std::cout << fmt::format("Output: {}", tensorOutput.data()) << std::endl;
 }
 ```
-
-## Advanced Examples
-
-We cover more advanced examples and applications of Vulkan Kompute, such as machine learning algorithms built on top of Kompute.
-
-You can find these in the end to end examples [section](#end-to-end-examples).
-
 
 ## Components & Architecture
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Vulkan Kompute'
-copyright = '2020, Alejandro Saucedo'
+copyright = '2020, The Institute for Ethical AI & Machine Learning'
 author = 'Alejandro Saucedo'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.0'
+release = '0.3.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,10 @@ Index
     :maxdepth: 2
     :titlesonly:
 
-    Advanced Examples <overview/advanced-examples.rst>
+    Advanced Examples <overview/advanced-examples>
+    Mobile App Intergration (Android) <overview/mobile-android>
+    Game Engine Integration (Godot Engine) <overview/game-engine-godot>
+    Converting GLSL/HLSL Shaders to C++ Headers <overview/shaders-to-headers>
     Class Reference <overview/reference>
     Memory management principles <overview/memory-management>
     Code Index <genindex>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ Index
     Mobile App Intergration (Android) <overview/mobile-android>
     Game Engine Integration (Godot Engine) <overview/game-engine-godot>
     Converting GLSL/HLSL Shaders to C++ Headers <overview/shaders-to-headers>
-    Class Reference <overview/reference>
-    Memory management principles <overview/memory-management>
+    Asynchronous & Parallel Operations <overview/async-parallel>
+    Class Documentation and C++ Reference <overview/reference>
+    Memory Management Principles <overview/memory-management>
     Code Index <genindex>
 

--- a/docs/overview/advanced-examples.rst
+++ b/docs/overview/advanced-examples.rst
@@ -2,8 +2,15 @@
 Advanced Examples
 ==================
 
-The power of Kompute comes in when the interface is used for complex computations. In this section we cover a set of advanced examples including machine learning and data processing applications that showcase the more advanced capabilities of Kompute.
+The power of Kompute comes in when the interface is used for complex computations. This section contains an outline of the advanced / end-to-end examples available.
 
+Currently the advanced examples available include:
+
+* `Machine Learning Logistic Regression Implementation <https://towardsdatascience.com/machine-learning-and-data-processing-in-the-gpu-with-vulkan-kompute-c9350e5e5d3a`_
+* `Android NDK Mobile Kompute ML Application <https://towardsdatascience.com/gpu-accelerated-machine-learning-in-your-mobile-applications-using-the-android-ndk-vulkan-kompute-1e9da37b7617`_
+* `Game Development Kompute ML in Godot Engine <https://towardsdatascience.com/supercharging-game-development-with-gpu-accelerated-ml-using-vulkan-kompute-the-godot-game-engine-4e75a84ea9f0`_
+
+Below there is also a simple implementation of the logistic regression algorithm using Vulkan Kompute.
 
 Logistic Regression Example
 ------------------

--- a/docs/overview/async-parallel.rst
+++ b/docs/overview/async-parallel.rst
@@ -1,0 +1,108 @@
+
+Asynchronous and Parallel Operations
+=============
+
+In GPU computing it is possible to have multiple levels of asynchronous and parallel processing of GPU tasks.
+
+It is important to understand the conceptual distinctions of the diffent terminology when using each of these components.
+
+In this section we will cover the following points:
+
+* Asynchronous operation submission
+* Parallel processing of operations
+
+Asynchronous operation submission
+---------------------------------
+
+As the name implies, this refers to the asynchronous submission of operations. This means that operations can be submitted to the GPU, and the C++ / host CPU can continue performing tasks, until when the user desires to run `await` to wait until the operation finishes.
+
+This basically provides further granularity on Vulkan Fences, which is its means to enable the CPU host to know when GPU commands have finished executing. 
+
+It is important that submitting tasks asynchronously, does not mean that these will be executed in parallel. Parallel execution of operations will be covered in the following section.
+
+Asynchronous operation submission can be achieved through the kp::Manager, or directly through the kp::Sequence. Below is an example using the Kompute manager.
+
+Async/Await Example
+^^^^^^^^^^^^^^^^^^^^^
+
+Asynchronous job submission is done using `evalOpAsync` and `evalOpAwait` functions.
+
+For simplicity the `evalOpAsyncDefault` and `evalOpAwaitDefault` functions are provided, which can be used similar to the synchronous counterparts (which basically use the default named sequence).
+
+A simple example of asynchronous submission can be found below.
+
+One important thing to bare in mind when using asynchronous submissions, is that you should make sure that any overlapping asynchronous functions are run in separate sequences.
+
+The reason why this is important is that the Await function not only waits for the fence, but also runs the `postEval` functions across all operations, which is required for several operations.
+
+.. code-block:: cpp
+    :linenos:
+
+    // You can allow Kompute to create the Vulkan components, or pass your existing ones
+    kp::Manager mgr; // Selects device 0 unless explicitly requested
+
+    // Creates tensor an initializes GPU memory (below we show more granularity)
+    auto tensor = std::make_shared<kp::Tensor>(kp::Tensor(std::vector<float>(10, 0.0)));
+
+    // Create tensors data explicitly in GPU with an operation
+    mgr.evalOpAsyncDefault<kp::OpTensorCreate>({ tensor });
+
+    // Define your shader as a string (using string literals for simplicity)
+    // (You can also pass the raw compiled bytes, or even path to file)
+    std::string shader(R"(
+        #version 450
+
+        layout (local_size_x = 1) in;
+
+        layout(set = 0, binding = 0) buffer b { float pb[]; };
+
+        shared uint sharedTotal[1];
+
+        void main() {
+            uint index = gl_GlobalInvocationID.x;
+
+            sharedTotal[0] = 0;
+
+            // Iterating to simulate longer process
+            for (int i = 0; i < 100000000; i++)
+            {
+                atomicAdd(sharedTotal[0], 1);
+            }
+
+            pb[index] = sharedTotal[0];
+        }
+    )");
+
+    // We can now await for the previous submitted command
+    // The first parameter can be the amount of time to wait
+    // The time provided is in nanoseconds
+    mgr.evalOpAwaitDefault(10000);
+
+    // Run Async Kompute operation on the parameters provided
+    mgr.evalOpAsyncDefault<kp::OpAlgoBase<>>(
+        { tensor }, 
+        std::vector<char>(shader.begin(), shader.end()));
+
+    // Here we can do other work
+
+    // When we're ready we can wait 
+    // The default wait time is UINT64_MAX
+    mgr.evalOpAwaitDefault()
+
+    // Sync the GPU memory back to the local tensor
+    // We can still run synchronous jobs in our created sequence
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensor });
+
+    // Prints the output: B: { 100000000, ... }
+    std::cout << fmt::format("B: {}", 
+        tensor.data()) << std::endl;
+
+
+Parallel Operation Submission
+-----------
+
+In order to work with parallel execution of tasks, it is important that you understand some of the core GPU processing limitations, as these can be quite broad and hardware dependent, which means they will vary across NVIDIA / AMD / ETC video cards.
+
+GPUs by default will optimize towards GPU 
+
+

--- a/docs/overview/game-engine-godot.rst
+++ b/docs/overview/game-engine-godot.rst
@@ -1,0 +1,7 @@
+
+.. mdinclude:: ../../examples/godot_logistic_regression/README.md
+
+.. mdinclude:: ../../examples/godot_logistic_regression/custom_module/README.md
+
+.. mdinclude:: ../../examples/godot_logistic_regression/gdnative_shared/README.md
+

--- a/docs/overview/memory-management.rst
+++ b/docs/overview/memory-management.rst
@@ -3,12 +3,25 @@ Memory Management Principles
 =====================
 
 The principle in Vulkan Kompute on memory management is summarised as follows:
+
 * Explicit is better than implicit for specifying memory management 
 * Interfaces for memory management are constant until freed
 * Memory management responsibilities are acyclic from static object references
+* Memory management by Kompute is optional and only in place if resource is created by Kompute
 
 Vulkan Kompute is responsible for managing both the CPU and GPU memory allocations and resources, and is important that they are able to explicitly define when these objects are released or destroyed. Similarly, it's important that the memory resources created by the application are released safely.
 
 Vulkan Kompute is built with the BYOV principle in mind (Bring your own Vulkan). This means that even though the top level resources are managing the memory to its owned resources, they themselves may not have full ownership of the GPU / Vulkan components themselves.
+
+The memory ownership is hierarchically outlined in the component architecture - in this diagram, the arrows provide an intuition on the memory management ownership relationships (in this case you can ignore the arrow from the Algorithm, as this is the only one that as of today doesn't manage the memory of the Tensors).
+
+.. image:: ../images/kompute-architecture.jpg
+   :width: 100%
+
+Optional Memory Management
+-------------
+
+As outlined above, resource memory is only managed by Kompute if the resources are created by Kompute. Each of the Kompute components can also be initialised with externally managed resources. The kp::Manager for example can be initialized with an external Vulkan Device. The first principle ensures that all memory ownership is explicitly defined when managing and creating Kompute resources.
+
 
 

--- a/docs/overview/mobile-android.rst
+++ b/docs/overview/mobile-android.rst
@@ -1,0 +1,3 @@
+
+.. mdinclude:: ../../examples/android/android-simple/README.md
+

--- a/docs/overview/reference.rst
+++ b/docs/overview/reference.rst
@@ -1,5 +1,5 @@
 
-Reference
+Class Documentation and C++ Reference
 ========
 
 This section provides a breakdown of the cpp classes and what each of their functions provide. It is partially generated and augomented from the Doxygen autodoc content. You can also go directly to the `raw doxygen docs <../doxygen/annotated.html>`_.

--- a/docs/overview/shaders-to-headers.rst
+++ b/docs/overview/shaders-to-headers.rst
@@ -1,0 +1,47 @@
+
+
+Converting Shaders to C++ Headers
+=====================
+
+Kompute allows for shaders to be loaded directly through the kp::OpAlgoBase as either raw strings (through shaderc) or compiled SPIRV bytes. For this latter, the traditional method of including the SPIRV bytes is by loading the SPIRV file directly and passing the contents.
+
+The Kompute codebase has a utility that allows you to convert shader files into C++ header files containing the SPIRV header data. This is useful as it enables developers to compile the SPIRV shaders into the final binary, which avoids the need for multiple files being required.
+
+The utility can be found under `scripts/convert_shaders.py <https://github.com/EthicalML/vulkan-kompute/blob/master/scripts/convert_shaders.py>`_ and consists primarily of a Python CLI that can be called to pass arguments.
+
+In order to use this Python utility, you will have to first install the dependencies outlined by the `scripts/requirements.txt` file. You will need to have python 3 and pip3 installed.
+
+.. code-block:: bash
+    :linenos:
+
+    python3 -m pip install -r scripts/requirements.txt
+
+Once the dependencies can be installed, you can run the Python script directly through the file as `python3 scripts/convert_shaders.py`.
+
+You can run `python3 scripts/convert_shaders.py --help` to see all the options available - namely:
+
+.. code-block:: bash
+    :linenos:
+
+    > python3 scripts/convert_shaders.py --help
+
+    Usage: convert_shaders.py [OPTIONS]
+
+      CLI function for shader generation
+
+    Options:
+      -p, --shader-path TEXT    The path for the directory to build and convert
+                                shaders  [required]
+
+      -s, --shader-binary TEXT  The path for the directory to build and convert
+                                shaders  [required]
+
+      -c, --header-path TEXT    The (optional) output file for the cpp header
+                                files
+
+      -v, --verbose             Enable versbosity if flag is provided
+      --help                    Show this message and exit.
+
+You can see the command that converts the shaders `in the makefile <https://github.com/EthicalML/vulkan-kompute/blob/45ddfe524b9ed63c5fe1fc33773c8f93a18e2fac/Makefile#L143>`_ to get an idea of how you would be able to use this utility.
+
+

--- a/examples/android/android-simple/README.md
+++ b/examples/android/android-simple/README.md
@@ -1,10 +1,12 @@
 
+# Kompute Mobile App Integration (Android)
+
+This is the accompanying code for the Blog post ["Supercharging your Mobile Apps with On-Device GPU Accelerated Machine Learning using the Android NDK & Vulkan Kompute"](https://towardsdatascience.com/gpu-accelerated-machine-learning-in-your-mobile-applications-using-the-android-ndk-vulkan-kompute-1e9da37b7617). 
+
 <table>
 <tr>
 
-
 <td width="70%">
-<h1>Vulkan Kompute Android</h1>
 <h3>Example Running Logistic Regression with Vulkan Kompute in Android Phones</h3>
 
 <p>
@@ -14,6 +16,9 @@ The example uses the Kompute build in the relative folder to build the respectiv
 
 The build structure provides a range of options to build in different Android hardware. This example was tested in various emulators including Pixel 2, and a physical Samsung S7 phone.
 </p>
+
+<br>
+
 <img src="https://raw.githubusercontent.com/EthicalML/vulkan-kompute/android-example/docs/images/android-editor.jpg">
 
 </td>

--- a/examples/godot_logistic_regression/README.md
+++ b/examples/godot_logistic_regression/README.md
@@ -1,4 +1,5 @@
-# Godot Kompute ML Example
+
+# Kompute Game Engine Integration (Godot)
 
 ![](https://github.com/EthicalML/vulkan-kompute/raw/master/docs/images/komputer-godot-4.gif)
 

--- a/examples/godot_logistic_regression/custom_module/README.md
+++ b/examples/godot_logistic_regression/custom_module/README.md
@@ -1,4 +1,9 @@
-# Vulkan Kompute Godot Example
+
+## Godot Engine Integration: Godot Engine Source Module
+
+This is the accompanying code for the Blog post ["Supercharging Game Development with GPU Accelerated Machine Learning"](https://medium.com/@AxSaucedo/supercharging-game-development-with-gpu-accelerated-ml-using-vulkan-kompute-the-godot-game-engine-4e75a84ea9f0). 
+
+This section contains the implementation of the Kompute module as a statically compile module built with the Godot engine source code. This approach requires re-compiling the Godot engine source code.
 
 ![](https://github.com/EthicalML/vulkan-kompute/raw/master/docs/images/komputer-godot-4.gif)
 

--- a/examples/godot_logistic_regression/gdnative_shared/README.md
+++ b/examples/godot_logistic_regression/gdnative_shared/README.md
@@ -1,8 +1,14 @@
-# Vulkan Kompute Godot Example
+
+## Godot Engine Integration: GdNative Library
+
+This is the accompanying code for the Blog post ["Supercharging Game Development with GPU Accelerated Machine Learning"](https://medium.com/@AxSaucedo/supercharging-game-development-with-gpu-accelerated-ml-using-vulkan-kompute-the-godot-game-engine-4e75a84ea9f0). 
+
+This section contains the implementation of the Kompute module as a shared GdNative Library that can be loaded dynamically through the Godot engine. This approach does not require re-compiling the Godot engine source code.
+
 
 ![](https://github.com/EthicalML/vulkan-kompute/raw/master/docs/images/komputer-godot-4.gif)
 
-## Set Up Dependencies
+### Set Up Dependencies
 
 We can get all the required dependencies from godot by running
 

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -18,7 +18,9 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #ifndef KOMPUTE_VK_API_MINOR_VERSION
 #define KOMPUTE_VK_API_MINOR_VERSION 1
 #endif // KOMPUTE_VK_API_MINOR_VERSION
-#define KOMPUTE_VK_API_VERSION VK_MAKE_VERSION(KOMPUTE_VK_API_MAJOR_VERSION, KOMPUTE_VK_API_MINOR_VERSION, 0)
+#define KOMPUTE_VK_API_VERSION                                                 \
+    VK_MAKE_VERSION(                                                           \
+      KOMPUTE_VK_API_MAJOR_VERSION, KOMPUTE_VK_API_MINOR_VERSION, 0)
 #endif // KOMPUTE_VK_API_VERSION
 
 // SPDLOG_ACTIVE_LEVEL must be defined before spdlog.h import
@@ -39,7 +41,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_DEBUG(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_DEBUG(message, ...) ((void)__android_log_print(ANDROID_LOG_DEBUG, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_DEBUG(message, ...)                                             \
+    ((void)__android_log_print(ANDROID_LOG_DEBUG, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_DEBUG(message, ...)                                             \
     std::cout << "DEBUG: " << message << std::endl
@@ -49,7 +52,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_INFO(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_INFO(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_INFO(message, ...)                                              \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_INFO(message, ...) std::cout << "INFO: " << message << std::endl
 #endif // VK_USE_PLATFORM_ANDROID_KHR
@@ -58,7 +62,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_WARN(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_WARN(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_WARN(message, ...)                                              \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_WARN(message, ...)                                              \
     std::cout << "WARNING: " << message << std::endl
@@ -68,7 +73,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_ERROR(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_ERROR(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_ERROR(message, ...)                                             \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_ERROR(message, ...)                                             \
     std::cout << "ERROR: " << message << std::endl
@@ -1055,14 +1061,17 @@ class Sequence
     bool eval();
 
     /**
-     * Eval Async sends all the recorded and stored operations in the vector of operations into the gpu as a submit job with a barrier. EvalAwait() must be called after to ensure the sequence is terminated correctly.
+     * Eval Async sends all the recorded and stored operations in the vector of
+     * operations into the gpu as a submit job with a barrier. EvalAwait() must
+     * be called after to ensure the sequence is terminated correctly.
      *
      * @return Boolean stating whether execution was successful.
      */
     bool evalAsync();
 
     /**
-     * Eval Await waits for the fence to finish processing and then once it finishes, it runs the postEval of all operations.
+     * Eval Await waits for the fence to finish processing and then once it
+     * finishes, it runs the postEval of all operations.
      *
      * @param waitFor Number of milliseconds to wait before timing out.
      * @return Boolean stating whether execution was successful.
@@ -1077,7 +1086,8 @@ class Sequence
     bool isRecording();
 
     /**
-     * Returns true if the sequence is currently running - mostly used for async workloads.
+     * Returns true if the sequence is currently running - mostly used for async
+     * workloads.
      *
      * @return Boolean stating if currently running.
      */
@@ -1245,7 +1255,7 @@ namespace kp {
 */
 class Manager
 {
-public:
+  public:
     /**
         Base constructor and default used which creates the base resources
        including choosing the device 0 by default.
@@ -1253,14 +1263,16 @@ public:
     Manager();
 
     /**
-      * Similar to base constructor but allows the user to provide the device
-      * they would like to create the resources on.
-      *
-      * @param physicalDeviceIndex The index of the physical device to use
-      * @param familyQueueIndeces (Optional) List of queue indeces to add for explicit allocation
-      * @param totalQueues The total number of compute queues to create.
-    */
-    Manager(uint32_t physicalDeviceIndex, const std::vector<uint32_t> & familyQueueIndeces = {});
+     * Similar to base constructor but allows the user to provide the device
+     * they would like to create the resources on.
+     *
+     * @param physicalDeviceIndex The index of the physical device to use
+     * @param familyQueueIndeces (Optional) List of queue indeces to add for
+     * explicit allocation
+     * @param totalQueues The total number of compute queues to create.
+     */
+    Manager(uint32_t physicalDeviceIndex,
+            const std::vector<uint32_t>& familyQueueIndeces = {});
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
@@ -1295,14 +1307,15 @@ public:
       std::string sequenceName);
 
     /**
-     * Create a new managed Kompute sequence so it's available within the manager.
+     * Create a new managed Kompute sequence so it's available within the
+     * manager.
      *
      * @param sequenceName The name for the named sequence to be created
      * @param queueIndex The queue to use from the available queues
      * @return Weak pointer to the manager owned sequence resource
      */
-    std::weak_ptr<Sequence> createManagedSequence(
-      std::string sequenceName, uint32_t queueIndex = 0);
+    std::weak_ptr<Sequence> createManagedSequence(std::string sequenceName,
+                                                  uint32_t queueIndex = 0);
 
     /**
      * Operation that adds extra operations to existing or new created
@@ -1349,15 +1362,15 @@ public:
      */
     template<typename T, typename... TArgs>
     void evalOpAsync(std::vector<std::shared_ptr<Tensor>> tensors,
-                std::string sequenceName,
-                TArgs&&... params)
+                     std::string sequenceName,
+                     TArgs&&... params)
     {
         SPDLOG_DEBUG("Kompute Manager evalOpAsync triggered");
         std::weak_ptr<Sequence> sqWeakPtr =
           this->getOrCreateManagedSequence(sequenceName);
 
-        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
-          this->mManagedSequences.find(sequenceName);
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
+          found = this->mManagedSequences.find(sequenceName);
 
         if (found != this->mManagedSequences.end()) {
             std::shared_ptr<Sequence> sq = found->second;
@@ -1373,9 +1386,9 @@ public:
 
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence EVAL");
             sq->evalAsync();
-        }
-        else {
-            SPDLOG_ERROR("Kompute Manager evalOpAsync sequence [{}] not found", sequenceName);
+        } else {
+            SPDLOG_ERROR("Kompute Manager evalOpAsync sequence [{}] not found",
+                         sequenceName);
         }
         SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence SUCCESS");
     }
@@ -1391,21 +1404,22 @@ public:
     void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
     {
         SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
-        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
-        this->mManagedSequences.find(sequenceName);
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
+          found = this->mManagedSequences.find(sequenceName);
 
         if (found != this->mManagedSequences.end()) {
             if (std::shared_ptr<kp::Sequence> sq = found->second) {
-                SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence Sequence EVAL AWAIT");
+                SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence "
+                             "Sequence EVAL AWAIT");
                 if (sq->isRunning()) {
                     sq->evalAwait(waitFor);
                 }
             }
-            SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
-        }
-        else {
+            SPDLOG_DEBUG(
+              "Kompute Manager evalOpAwait running sequence SUCCESS");
+        } else {
             SPDLOG_ERROR("Kompute Manager evalOpAwait Sequence not found");
- 		}
+        }
     }
 
     /**
@@ -1475,7 +1489,7 @@ public:
 
     // Create functions
     void createInstance();
-    void createDevice(const std::vector<uint32_t> & familyQueueIndeces = {});
+    void createDevice(const std::vector<uint32_t>& familyQueueIndeces = {});
 };
 
 } // End namespace kp

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -1358,7 +1358,7 @@ class Manager
         std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
           this->mManagedSequences.find(sequenceName);
 
-        if (found == this->mManagedSequences.end()) {
+        if (found != this->mManagedSequences.end()) {
             std::shared_ptr<Sequence> sq = found->second;
 
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence BEGIN");

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -1253,19 +1253,22 @@ class Manager
     Manager();
 
     /**
-        Similar to base constructor but allows the user to provide the device
-       they would like to create the resources on.
+      * Similar to base constructor but allows the user to provide the device
+      * they would like to create the resources on.
+      *
+      * @param physicalDeviceIndex The index of the physical device to use
+      * @param totalQueues The total number of compute queues to create.
     */
-    Manager(uint32_t physicalDeviceIndex);
+    Manager(uint32_t physicalDeviceIndex, uint32_t totalComputeQueues = 1);
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
      * with the vulkan kompute use.
      *
      * @param instance Vulkan compute instance to base this application
-     * @physicalDevice Vulkan physical device to use for application
-     * @device Vulkan logical device to use for all base resources
-     * @physicalDeviceIndex Index for vulkan physical device used
+     * @param physicalDevice Vulkan physical device to use for application
+     * @param device Vulkan logical device to use for all base resources
+     * @param physicalDeviceIndex Index for vulkan physical device used
      */
     Manager(std::shared_ptr<vk::Instance> instance,
             std::shared_ptr<vk::PhysicalDevice> physicalDevice,
@@ -1289,6 +1292,16 @@ class Manager
      */
     std::weak_ptr<Sequence> getOrCreateManagedSequence(
       std::string sequenceName);
+
+    /**
+     * Create a new managed Kompute sequence so it's available within the manager.
+     *
+     * @param sequenceName The name for the named sequence to be created
+     * @param queueIndex The queue to use from the available queues
+     * @return Weak pointer to the manager owned sequence resource
+     */
+    std::weak_ptr<Sequence> createManagedSequence(
+      std::string sequenceName, uint32_t queueIndex = 0);
 
     /**
      * Operation that adds extra operations to existing or new created
@@ -1342,7 +1355,12 @@ class Manager
         std::weak_ptr<Sequence> sqWeakPtr =
           this->getOrCreateManagedSequence(sequenceName);
 
-        if (std::shared_ptr<kp::Sequence> sq = sqWeakPtr.lock()) {
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
+          this->mManagedSequences.find(sequenceName);
+
+        if (found == this->mManagedSequences.end()) {
+            std::shared_ptr<Sequence> sq = found->second;
+
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence BEGIN");
             sq->begin();
 
@@ -1354,6 +1372,9 @@ class Manager
 
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence EVAL");
             sq->evalAsync();
+        }
+        else {
+            SPDLOG_ERROR("Kompute Manager evalOpAsync sequence [{}] not found", sequenceName);
         }
         SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence SUCCESS");
     }
@@ -1382,7 +1403,7 @@ class Manager
             SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
         }
         else {
-            SPDLOG_ERROR("Sequence not found");
+            SPDLOG_ERROR("Kompute Manager evalOpAwait Sequence not found");
  		}
     }
 
@@ -1437,7 +1458,7 @@ class Manager
     std::shared_ptr<vk::Device> mDevice = nullptr;
     bool mFreeDevice = false;
     uint32_t mComputeQueueFamilyIndex = -1;
-    std::shared_ptr<vk::Queue> mComputeQueue = nullptr;
+    std::vector<std::shared_ptr<vk::Queue>> mComputeQueues;
 
     // -------------- ALWAYS OWNED RESOURCES
     std::unordered_map<std::string, std::shared_ptr<Sequence>>
@@ -1452,7 +1473,7 @@ class Manager
 
     // Create functions
     void createInstance();
-    void createDevice();
+    void createDevice(uint32_t totalComputeQueues);
 };
 
 } // End namespace kp

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -1245,7 +1245,7 @@ namespace kp {
 */
 class Manager
 {
-  public:
+public:
     /**
         Base constructor and default used which creates the base resources
        including choosing the device 0 by default.
@@ -1257,9 +1257,10 @@ class Manager
       * they would like to create the resources on.
       *
       * @param physicalDeviceIndex The index of the physical device to use
+      * @param familyQueueIndeces (Optional) List of queue indeces to add for explicit allocation
       * @param totalQueues The total number of compute queues to create.
     */
-    Manager(uint32_t physicalDeviceIndex, uint32_t totalComputeQueues = 1);
+    Manager(uint32_t physicalDeviceIndex, const std::vector<uint32_t> & familyQueueIndeces = {});
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
@@ -1457,12 +1458,13 @@ class Manager
     uint32_t mPhysicalDeviceIndex = -1;
     std::shared_ptr<vk::Device> mDevice = nullptr;
     bool mFreeDevice = false;
-    uint32_t mComputeQueueFamilyIndex = -1;
-    std::vector<std::shared_ptr<vk::Queue>> mComputeQueues;
 
     // -------------- ALWAYS OWNED RESOURCES
     std::unordered_map<std::string, std::shared_ptr<Sequence>>
       mManagedSequences;
+
+    std::vector<uint32_t> mComputeQueueFamilyIndeces;
+    std::vector<std::shared_ptr<vk::Queue>> mComputeQueues;
 
 #if DEBUG
 #ifndef KOMPUTE_DISABLE_VK_DEBUG_LAYERS
@@ -1473,7 +1475,7 @@ class Manager
 
     // Create functions
     void createInstance();
-    void createDevice(uint32_t totalComputeQueues);
+    void createDevice(const std::vector<uint32_t> & familyQueueIndeces = {});
 };
 
 } // End namespace kp

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -1318,8 +1318,7 @@ class Manager
                                                   uint32_t queueIndex = 0);
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Function that evaluates operation against named sequence.
      *
      * @param tensors The tensors to be used in the operation recorded
      * @param sequenceName The name of the sequence to be retrieved or created
@@ -1352,8 +1351,23 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Function that evaluates operation against default sequence.
+     *
+     * @param tensors The tensors to be used in the operation recorded
+     * @param TArgs Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpDefault(std::vector<std::shared_ptr<Tensor>> tensors,
+                       TArgs&&... params)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOp Default triggered");
+        this->evalOp<T>(
+          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+    }
+
+    /**
+     * Function that evaluates operation against named sequence asynchronously.
      *
      * @param tensors The tensors to be used in the operation recorded
      * @param sequenceName The name of the sequence to be retrieved or created
@@ -1394,16 +1408,30 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Operation that evaluates operation against default sequence asynchronously.
+     *
+     * @param tensors The tensors to be used in the operation recorded
+     * @param params Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpAsyncDefault(std::vector<std::shared_ptr<Tensor>> tensors,
+                     TArgs&&... params)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOpAsyncDefault triggered");
+        this->evalOpAsync<T>(
+          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+    }
+
+    /**
+     * Operation that awaits for named sequence to finish.
      *
      * @param sequenceName The name of the sequence to wait for termination
      * @param waitFor The amount of time to wait before timing out
      */
-    template<typename... TArgs>
     void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
     {
-        SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
+        SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered with sequence {}", sequenceName);
         std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
           found = this->mManagedSequences.find(sequenceName);
 
@@ -1423,20 +1451,16 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Operation that awaits for default sequence to finish.
      *
      * @param tensors The tensors to be used in the operation recorded
-     * @param TArgs Template parameters that will be used to initialise
+     * @param params Template parameters that will be used to initialise
      * Operation to allow for extensible configurations on initialisation
      */
-    template<typename T, typename... TArgs>
-    void evalOpDefault(std::vector<std::shared_ptr<Tensor>> tensors,
-                       TArgs&&... params)
+    void evalOpAwaitDefault(uint64_t waitFor = UINT64_MAX)
     {
-        SPDLOG_DEBUG("Kompute Manager evalOp Default triggered");
-        this->evalOp<T>(
-          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+        SPDLOG_DEBUG("Kompute Manager evalOpAwaitDefault triggered");
+        this->evalOpAwait(KP_DEFAULT_SESSION, waitFor);
     }
 
     /**

--- a/src/Algorithm.cpp
+++ b/src/Algorithm.cpp
@@ -266,8 +266,7 @@ Algorithm::createPipeline(std::vector<uint32_t> specializationData)
 
 #ifdef KOMPUTE_CREATE_PIPELINE_RESULT_VALUE
     vk::ResultValue<vk::Pipeline> pipelineResult =
-      this->mDevice->createComputePipeline(*this->mPipelineCache,
-pipelineInfo);
+      this->mDevice->createComputePipeline(*this->mPipelineCache, pipelineInfo);
 
     if (pipelineResult.result != vk::Result::eSuccess) {
         throw std::runtime_error("Failed to create pipeline result: " +

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -28,7 +28,8 @@ Manager::Manager()
   : Manager(0)
 {}
 
-Manager::Manager(uint32_t physicalDeviceIndex, const std::vector<uint32_t> & familyQueueIndeces)
+Manager::Manager(uint32_t physicalDeviceIndex,
+                 const std::vector<uint32_t>& familyQueueIndeces)
 {
     this->mPhysicalDeviceIndex = physicalDeviceIndex;
 
@@ -105,9 +106,13 @@ Manager::getOrCreateManagedSequence(std::string sequenceName)
 }
 
 std::weak_ptr<Sequence>
-Manager::createManagedSequence(std::string sequenceName, uint32_t queueIndex) {
+Manager::createManagedSequence(std::string sequenceName, uint32_t queueIndex)
+{
 
-    SPDLOG_DEBUG("Kompute Manager createManagedSequence with sequenceName: {} and queueIndex: {}", sequenceName, queueIndex);
+    SPDLOG_DEBUG("Kompute Manager createManagedSequence with sequenceName: {} "
+                 "and queueIndex: {}",
+                 sequenceName,
+                 queueIndex);
 
     std::shared_ptr<Sequence> sq =
       std::make_shared<Sequence>(this->mPhysicalDevice,
@@ -205,7 +210,7 @@ Manager::createInstance()
 }
 
 void
-Manager::createDevice(const std::vector<uint32_t> & familyQueueIndeces)
+Manager::createDevice(const std::vector<uint32_t>& familyQueueIndeces)
 {
 
     SPDLOG_DEBUG("Kompute Manager creating Device");
@@ -246,7 +251,8 @@ Manager::createDevice(const std::vector<uint32_t> & familyQueueIndeces)
             vk::QueueFamilyProperties queueFamilyProperties =
               allQueueFamilyProperties[i];
 
-            if (queueFamilyProperties.queueFlags & vk::QueueFlagBits::eCompute) {
+            if (queueFamilyProperties.queueFlags &
+                vk::QueueFlagBits::eCompute) {
                 computeQueueFamilyIndex = i;
                 break;
             }
@@ -257,8 +263,7 @@ Manager::createDevice(const std::vector<uint32_t> & familyQueueIndeces)
         }
 
         this->mComputeQueueFamilyIndeces.push_back(computeQueueFamilyIndex);
-    }
-    else {
+    } else {
         this->mComputeQueueFamilyIndeces = familyQueueIndeces;
     }
 
@@ -277,28 +282,28 @@ Manager::createDevice(const std::vector<uint32_t> & familyQueueIndeces)
 
         // Creating the respective device queue
         vk::DeviceQueueCreateInfo deviceQueueCreateInfo(
-                vk::DeviceQueueCreateFlags(),
-                familyQueueInfo.first,
-                familyQueueInfo.second,
-                familyQueuePriorities[familyQueueInfo.first].data());
+          vk::DeviceQueueCreateFlags(),
+          familyQueueInfo.first,
+          familyQueueInfo.second,
+          familyQueuePriorities[familyQueueInfo.first].data());
         deviceQueueCreateInfos.push_back(deviceQueueCreateInfo);
     }
 
     vk::DeviceCreateInfo deviceCreateInfo(vk::DeviceCreateFlags(),
-        deviceQueueCreateInfos.size(),
-        deviceQueueCreateInfos.data());
+                                          deviceQueueCreateInfos.size(),
+                                          deviceQueueCreateInfos.data());
 
     this->mDevice = std::make_shared<vk::Device>();
     physicalDevice.createDevice(
       &deviceCreateInfo, nullptr, this->mDevice.get());
     SPDLOG_DEBUG("Kompute Manager device created");
 
-    for (const uint32_t & familyQueueIndex : this->mComputeQueueFamilyIndeces) 
-    {
+    for (const uint32_t& familyQueueIndex : this->mComputeQueueFamilyIndeces) {
         std::shared_ptr<vk::Queue> currQueue = std::make_shared<vk::Queue>();
 
-        this->mDevice->getQueue(
-          familyQueueIndex, familyQueueIndexCount[familyQueueIndex], currQueue.get());
+        this->mDevice->getQueue(familyQueueIndex,
+                                familyQueueIndexCount[familyQueueIndex],
+                                currQueue.get());
 
         familyQueueIndexCount[familyQueueIndex]++;
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -141,7 +141,8 @@ Sequence::evalAsync()
         return false;
     }
     if (this->mIsRunning) {
-        SPDLOG_WARN("Kompute Sequence evalAsync called when an eval async was called without successful wait");
+        SPDLOG_WARN("Kompute Sequence evalAsync called when an eval async was "
+                    "called without successful wait");
         return false;
     }
 
@@ -172,7 +173,8 @@ Sequence::evalAwait(uint64_t waitFor)
         return false;
     }
 
-    vk::Result result = this->mDevice->waitForFences(1, &this->mFence, VK_TRUE, waitFor);
+    vk::Result result =
+      this->mDevice->waitForFences(1, &this->mFence, VK_TRUE, waitFor);
     this->mDevice->destroy(this->mFence);
 
     if (result == vk::Result::eTimeout) {
@@ -191,7 +193,8 @@ Sequence::evalAwait(uint64_t waitFor)
 }
 
 bool
-Sequence::isRunning() {
+Sequence::isRunning()
+{
     return this->mIsRunning;
 }
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -151,8 +151,6 @@ Sequence::evalAsync()
         this->mOperations[i]->preEval();
     }
 
-    const vk::PipelineStageFlags waitStageMask =
-      vk::PipelineStageFlagBits::eTransfer & vk::PipelineStageFlagBits::eComputeShader;
     vk::SubmitInfo submitInfo(
       0, nullptr, nullptr, 1, this->mCommandBuffer.get());
 

--- a/src/include/kompute/Core.hpp
+++ b/src/include/kompute/Core.hpp
@@ -18,9 +18,10 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #ifndef KOMPUTE_VK_API_MINOR_VERSION
 #define KOMPUTE_VK_API_MINOR_VERSION 1
 #endif // KOMPUTE_VK_API_MINOR_VERSION
-#define KOMPUTE_VK_API_VERSION VK_MAKE_VERSION(KOMPUTE_VK_API_MAJOR_VERSION, KOMPUTE_VK_API_MINOR_VERSION, 0)
+#define KOMPUTE_VK_API_VERSION                                                 \
+    VK_MAKE_VERSION(                                                           \
+      KOMPUTE_VK_API_MAJOR_VERSION, KOMPUTE_VK_API_MINOR_VERSION, 0)
 #endif // KOMPUTE_VK_API_VERSION
-
 
 // SPDLOG_ACTIVE_LEVEL must be defined before spdlog.h import
 #if !defined(SPDLOG_ACTIVE_LEVEL)
@@ -40,7 +41,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_DEBUG(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_DEBUG(message, ...) ((void)__android_log_print(ANDROID_LOG_DEBUG, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_DEBUG(message, ...)                                             \
+    ((void)__android_log_print(ANDROID_LOG_DEBUG, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_DEBUG(message, ...)                                             \
     std::cout << "DEBUG: " << message << std::endl
@@ -50,7 +52,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_INFO(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_INFO(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_INFO(message, ...)                                              \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_INFO(message, ...) std::cout << "INFO: " << message << std::endl
 #endif // VK_USE_PLATFORM_ANDROID_KHR
@@ -59,7 +62,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_WARN(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_WARN(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_WARN(message, ...)                                              \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_WARN(message, ...)                                              \
     std::cout << "WARNING: " << message << std::endl
@@ -69,7 +73,8 @@ static const char* KOMPUTE_LOG_TAG = "KomputeLog";
 #define SPDLOG_ERROR(message, ...)
 #else
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#define SPDLOG_ERROR(message, ...) ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
+#define SPDLOG_ERROR(message, ...)                                             \
+    ((void)__android_log_print(ANDROID_LOG_INFO, KOMPUTE_LOG_TAG, message))
 #else
 #define SPDLOG_ERROR(message, ...)                                             \
     std::cout << "ERROR: " << message << std::endl

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -80,8 +80,7 @@ class Manager
                                                   uint32_t queueIndex = 0);
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Function that evaluates operation against named sequence.
      *
      * @param tensors The tensors to be used in the operation recorded
      * @param sequenceName The name of the sequence to be retrieved or created
@@ -114,8 +113,23 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Function that evaluates operation against default sequence.
+     *
+     * @param tensors The tensors to be used in the operation recorded
+     * @param TArgs Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpDefault(std::vector<std::shared_ptr<Tensor>> tensors,
+                       TArgs&&... params)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOp Default triggered");
+        this->evalOp<T>(
+          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+    }
+
+    /**
+     * Function that evaluates operation against named sequence asynchronously.
      *
      * @param tensors The tensors to be used in the operation recorded
      * @param sequenceName The name of the sequence to be retrieved or created
@@ -156,16 +170,30 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Operation that evaluates operation against default sequence asynchronously.
+     *
+     * @param tensors The tensors to be used in the operation recorded
+     * @param params Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpAsyncDefault(std::vector<std::shared_ptr<Tensor>> tensors,
+                     TArgs&&... params)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOpAsyncDefault triggered");
+        this->evalOpAsync<T>(
+          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+    }
+
+    /**
+     * Operation that awaits for named sequence to finish.
      *
      * @param sequenceName The name of the sequence to wait for termination
      * @param waitFor The amount of time to wait before timing out
      */
-    template<typename... TArgs>
     void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
     {
-        SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
+        SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered with sequence {}", sequenceName);
         std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
           found = this->mManagedSequences.find(sequenceName);
 
@@ -185,20 +213,16 @@ class Manager
     }
 
     /**
-     * Operation that adds extra operations to existing or new created
-     * sequences.
+     * Operation that awaits for default sequence to finish.
      *
      * @param tensors The tensors to be used in the operation recorded
-     * @param TArgs Template parameters that will be used to initialise
+     * @param params Template parameters that will be used to initialise
      * Operation to allow for extensible configurations on initialisation
      */
-    template<typename T, typename... TArgs>
-    void evalOpDefault(std::vector<std::shared_ptr<Tensor>> tensors,
-                       TArgs&&... params)
+    void evalOpAwaitDefault(uint64_t waitFor = UINT64_MAX)
     {
-        SPDLOG_DEBUG("Kompute Manager evalOp Default triggered");
-        this->evalOp<T>(
-          tensors, KP_DEFAULT_SESSION, std::forward<TArgs>(params)...);
+        SPDLOG_DEBUG("Kompute Manager evalOpAwaitDefault triggered");
+        this->evalOpAwait(KP_DEFAULT_SESSION, waitFor);
     }
 
     /**

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -101,6 +101,63 @@ class Manager
      * sequences.
      *
      * @param tensors The tensors to be used in the operation recorded
+     * @param sequenceName The name of the sequence to be retrieved or created
+     * @param TArgs Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpAsync(std::vector<std::shared_ptr<Tensor>> tensors,
+                std::string sequenceName,
+                TArgs&&... params)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOp triggered");
+        std::weak_ptr<Sequence> sqWeakPtr =
+          this->getOrCreateManagedSequence(sequenceName);
+
+        if (std::shared_ptr<kp::Sequence> sq = sqWeakPtr.lock()) {
+            SPDLOG_DEBUG("Kompute Manager evalOp running sequence BEGIN");
+            sq->begin();
+
+            SPDLOG_DEBUG("Kompute Manager evalOp running sequence RECORD");
+            sq->record<T>(tensors, std::forward<TArgs>(params)...);
+
+            SPDLOG_DEBUG("Kompute Manager evalOp running sequence END");
+            sq->end();
+
+            SPDLOG_DEBUG("Kompute Manager evalOp running sequence EVAL");
+            sq->evalAsync();
+        }
+        SPDLOG_DEBUG("Kompute Manager evalOp running sequence SUCCESS");
+    }
+
+    /**
+     * Operation that adds extra operations to existing or new created
+     * sequences.
+     *
+     * @param tensors The tensors to be used in the operation recorded
+     * @param sequenceName The name of the sequence to be retrieved or created
+     * @param TArgs Template parameters that will be used to initialise
+     * Operation to allow for extensible configurations on initialisation
+     */
+    template<typename T, typename... TArgs>
+    void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
+    {
+        SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
+        std::weak_ptr<Sequence> sqWeakPtr =
+          this->getOrCreateManagedSequence(sequenceName);
+
+        if (std::shared_ptr<kp::Sequence> sq = sqWeakPtr.lock()) {
+            SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence EVAL AWAIT");
+            sq->evalAwait(waitFor);
+        }
+        SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
+    }
+
+    /**
+     * Operation that adds extra operations to existing or new created
+     * sequences.
+     *
+     * @param tensors The tensors to be used in the operation recorded
      * @param TArgs Template parameters that will be used to initialise
      * Operation to allow for extensible configurations on initialisation
      */

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -143,14 +143,16 @@ class Manager
     void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
     {
         SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
-        std::weak_ptr<Sequence> sqWeakPtr =
-          this->getOrCreateManagedSequence(sequenceName);
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
+              this->mManagedSequences.find(sequenceName);
 
-        if (std::shared_ptr<kp::Sequence> sq = sqWeakPtr.lock()) {
-            SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence EVAL AWAIT");
-            sq->evalAwait(waitFor);
+        if (found == this->mManagedSequences.end()) {
+            if (std::shared_ptr<kp::Sequence> sq = found->second) {
+                SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence Sequence EVAL AWAIT");
+                sq->evalAwait(waitFor);
+            }
+            SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
         }
-        SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
     }
 
     /**

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -17,7 +17,7 @@ namespace kp {
 */
 class Manager
 {
-public:
+  public:
     /**
         Base constructor and default used which creates the base resources
        including choosing the device 0 by default.
@@ -25,14 +25,16 @@ public:
     Manager();
 
     /**
-      * Similar to base constructor but allows the user to provide the device
-      * they would like to create the resources on.
-      *
-      * @param physicalDeviceIndex The index of the physical device to use
-      * @param familyQueueIndeces (Optional) List of queue indeces to add for explicit allocation
-      * @param totalQueues The total number of compute queues to create.
-    */
-    Manager(uint32_t physicalDeviceIndex, const std::vector<uint32_t> & familyQueueIndeces = {});
+     * Similar to base constructor but allows the user to provide the device
+     * they would like to create the resources on.
+     *
+     * @param physicalDeviceIndex The index of the physical device to use
+     * @param familyQueueIndeces (Optional) List of queue indeces to add for
+     * explicit allocation
+     * @param totalQueues The total number of compute queues to create.
+     */
+    Manager(uint32_t physicalDeviceIndex,
+            const std::vector<uint32_t>& familyQueueIndeces = {});
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
@@ -67,14 +69,15 @@ public:
       std::string sequenceName);
 
     /**
-     * Create a new managed Kompute sequence so it's available within the manager.
+     * Create a new managed Kompute sequence so it's available within the
+     * manager.
      *
      * @param sequenceName The name for the named sequence to be created
      * @param queueIndex The queue to use from the available queues
      * @return Weak pointer to the manager owned sequence resource
      */
-    std::weak_ptr<Sequence> createManagedSequence(
-      std::string sequenceName, uint32_t queueIndex = 0);
+    std::weak_ptr<Sequence> createManagedSequence(std::string sequenceName,
+                                                  uint32_t queueIndex = 0);
 
     /**
      * Operation that adds extra operations to existing or new created
@@ -121,15 +124,15 @@ public:
      */
     template<typename T, typename... TArgs>
     void evalOpAsync(std::vector<std::shared_ptr<Tensor>> tensors,
-                std::string sequenceName,
-                TArgs&&... params)
+                     std::string sequenceName,
+                     TArgs&&... params)
     {
         SPDLOG_DEBUG("Kompute Manager evalOpAsync triggered");
         std::weak_ptr<Sequence> sqWeakPtr =
           this->getOrCreateManagedSequence(sequenceName);
 
-        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
-          this->mManagedSequences.find(sequenceName);
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
+          found = this->mManagedSequences.find(sequenceName);
 
         if (found != this->mManagedSequences.end()) {
             std::shared_ptr<Sequence> sq = found->second;
@@ -145,9 +148,9 @@ public:
 
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence EVAL");
             sq->evalAsync();
-        }
-        else {
-            SPDLOG_ERROR("Kompute Manager evalOpAsync sequence [{}] not found", sequenceName);
+        } else {
+            SPDLOG_ERROR("Kompute Manager evalOpAsync sequence [{}] not found",
+                         sequenceName);
         }
         SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence SUCCESS");
     }
@@ -163,21 +166,22 @@ public:
     void evalOpAwait(std::string sequenceName, uint64_t waitFor = UINT64_MAX)
     {
         SPDLOG_DEBUG("Kompute Manager evalOpAwait triggered");
-        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
-        this->mManagedSequences.find(sequenceName);
+        std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator
+          found = this->mManagedSequences.find(sequenceName);
 
         if (found != this->mManagedSequences.end()) {
             if (std::shared_ptr<kp::Sequence> sq = found->second) {
-                SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence Sequence EVAL AWAIT");
+                SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence "
+                             "Sequence EVAL AWAIT");
                 if (sq->isRunning()) {
                     sq->evalAwait(waitFor);
                 }
             }
-            SPDLOG_DEBUG("Kompute Manager evalOpAwait running sequence SUCCESS");
-        }
-        else {
+            SPDLOG_DEBUG(
+              "Kompute Manager evalOpAwait running sequence SUCCESS");
+        } else {
             SPDLOG_ERROR("Kompute Manager evalOpAwait Sequence not found");
- 		}
+        }
     }
 
     /**
@@ -247,7 +251,7 @@ public:
 
     // Create functions
     void createInstance();
-    void createDevice(const std::vector<uint32_t> & familyQueueIndeces = {});
+    void createDevice(const std::vector<uint32_t>& familyQueueIndeces = {});
 };
 
 } // End namespace kp

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -130,7 +130,7 @@ class Manager
         std::unordered_map<std::string, std::shared_ptr<Sequence>>::iterator found =
           this->mManagedSequences.find(sequenceName);
 
-        if (found == this->mManagedSequences.end()) {
+        if (found != this->mManagedSequences.end()) {
             std::shared_ptr<Sequence> sq = found->second;
 
             SPDLOG_DEBUG("Kompute Manager evalOpAsync running sequence BEGIN");

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -17,7 +17,7 @@ namespace kp {
 */
 class Manager
 {
-  public:
+public:
     /**
         Base constructor and default used which creates the base resources
        including choosing the device 0 by default.
@@ -29,9 +29,10 @@ class Manager
       * they would like to create the resources on.
       *
       * @param physicalDeviceIndex The index of the physical device to use
+      * @param familyQueueIndeces (Optional) List of queue indeces to add for explicit allocation
       * @param totalQueues The total number of compute queues to create.
     */
-    Manager(uint32_t physicalDeviceIndex, uint32_t totalComputeQueues = 1);
+    Manager(uint32_t physicalDeviceIndex, const std::vector<uint32_t> & familyQueueIndeces = {});
 
     /**
      * Manager constructor which allows your own vulkan application to integrate
@@ -229,12 +230,13 @@ class Manager
     uint32_t mPhysicalDeviceIndex = -1;
     std::shared_ptr<vk::Device> mDevice = nullptr;
     bool mFreeDevice = false;
-    uint32_t mComputeQueueFamilyIndex = -1;
-    std::vector<std::shared_ptr<vk::Queue>> mComputeQueues;
 
     // -------------- ALWAYS OWNED RESOURCES
     std::unordered_map<std::string, std::shared_ptr<Sequence>>
       mManagedSequences;
+
+    std::vector<uint32_t> mComputeQueueFamilyIndeces;
+    std::vector<std::shared_ptr<vk::Queue>> mComputeQueues;
 
 #if DEBUG
 #ifndef KOMPUTE_DISABLE_VK_DEBUG_LAYERS
@@ -245,7 +247,7 @@ class Manager
 
     // Create functions
     void createInstance();
-    void createDevice(uint32_t totalComputeQueues);
+    void createDevice(const std::vector<uint32_t> & familyQueueIndeces = {});
 };
 
 } // End namespace kp

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -67,14 +67,17 @@ class Sequence
     bool eval();
 
     /**
-     * Eval Async sends all the recorded and stored operations in the vector of operations into the gpu as a submit job with a barrier. EvalAwait() must be called after to ensure the sequence is terminated correctly.
+     * Eval Async sends all the recorded and stored operations in the vector of
+     * operations into the gpu as a submit job with a barrier. EvalAwait() must
+     * be called after to ensure the sequence is terminated correctly.
      *
      * @return Boolean stating whether execution was successful.
      */
     bool evalAsync();
 
     /**
-     * Eval Await waits for the fence to finish processing and then once it finishes, it runs the postEval of all operations.
+     * Eval Await waits for the fence to finish processing and then once it
+     * finishes, it runs the postEval of all operations.
      *
      * @param waitFor Number of milliseconds to wait before timing out.
      * @return Boolean stating whether execution was successful.
@@ -89,7 +92,8 @@ class Sequence
     bool isRecording();
 
     /**
-     * Returns true if the sequence is currently running - mostly used for async workloads.
+     * Returns true if the sequence is currently running - mostly used for async
+     * workloads.
      *
      * @return Boolean stating if currently running.
      */

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -45,18 +45,41 @@ class Sequence
     /**
      * Begins recording commands for commands to be submitted into the command
      * buffer.
+     *
+     * @return Boolean stating whether execution was successful.
      */
     bool begin();
+
     /**
      * Ends the recording and stops recording commands when the record command
      * is sent.
+     *
+     * @return Boolean stating whether execution was successful.
      */
     bool end();
+
     /**
      * Eval sends all the recorded and stored operations in the vector of
      * operations into the gpu as a submit job with a barrier.
+     *
+     * @return Boolean stating whether execution was successful.
      */
     bool eval();
+
+    /**
+     * Eval Async sends all the recorded and stored operations in the vector of operations into the gpu as a submit job with a barrier. EvalAwait() must be called after to ensure the sequence is terminated correctly.
+     *
+     * @return Boolean stating whether execution was successful.
+     */
+    bool evalAsync();
+
+    /**
+     * Eval Await waits for the fence to finish processing and then once it finishes, it runs the postEval of all operations.
+     *
+     * @param waitFor Number of milliseconds to wait before timing out.
+     * @return Boolean stating whether execution was successful.
+     */
+    bool evalAwait(uint64_t waitFor = UINT64_MAX);
 
     /**
      * Returns true if the sequence is currently in recording activated.
@@ -134,12 +157,14 @@ class Sequence
     std::shared_ptr<vk::CommandBuffer> mCommandBuffer = nullptr;
     bool mFreeCommandBuffer = false;
 
-    // Base op objects
+    // -------------- ALWAYS OWNED RESOURCES
+    vk::Fence mFence;
     std::vector<std::unique_ptr<OpBase>> mOperations;
 
     // State
     bool mIsInit = false;
     bool mRecording = false;
+    bool mEvalBusy = false;
 
     // Create functions
     void createCommandPool();

--- a/src/include/kompute/Sequence.hpp
+++ b/src/include/kompute/Sequence.hpp
@@ -89,6 +89,13 @@ class Sequence
     bool isRecording();
 
     /**
+     * Returns true if the sequence is currently running - mostly used for async workloads.
+     *
+     * @return Boolean stating if currently running.
+     */
+    bool isRunning();
+
+    /**
      * Returns true if the sequence has been successfully initialised.
      *
      * @return Boolean stating if sequence has been initialised.
@@ -164,7 +171,7 @@ class Sequence
     // State
     bool mIsInit = false;
     bool mRecording = false;
-    bool mEvalBusy = false;
+    bool mIsRunning = false;
 
     // Create functions
     void createCommandPool();

--- a/src/include/kompute/operations/OpAlgoBase.hpp
+++ b/src/include/kompute/operations/OpAlgoBase.hpp
@@ -162,7 +162,7 @@ OpAlgoBase<tX, tY, tZ>::OpAlgoBase(std::shared_ptr<vk::PhysicalDevice> physicalD
                            std::vector<std::shared_ptr<Tensor>>& tensors)
   : OpBase(physicalDevice, device, commandBuffer, tensors, false)
 {
-    SPDLOG_DEBUG("Kompute OpAlgoBase constructor with params numTensors: {} , shaderFilePath: {}", tensors.size());
+    SPDLOG_DEBUG("Kompute OpAlgoBase constructor with params numTensors: {}", tensors.size());
 
     // The dispatch size is set up based on either explicitly provided template
     // parameters or by default it would take the shape and size of the tensors

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -109,8 +109,6 @@ TEST(TestAsyncOperations, TestManagerAsync)
           std::vector<char>(shader.begin(), shader.end()));
     }
 
-    // TODO: Add function to print device details (or link)
-    // TODO: Seems to fail if await called twice
     for (uint32_t i = 0; i < numParallel; i++) {
         mgrAsync.evalOpAwait("async" + std::to_string(i));
     }
@@ -123,6 +121,9 @@ TEST(TestAsyncOperations, TestManagerAsync)
     for (uint32_t i = 0; i < numParallel; i++) {
         EXPECT_EQ(inputsAsyncB[i]->data(), resultAsync);
     }
+
+    SPDLOG_ERROR("sync {}", durationSync);
+    SPDLOG_ERROR("async {}", durationAsync);
 
     // The speedup should be at least 40% 
     EXPECT_LT(durationAsync, durationSync * 0.6);

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -7,6 +7,9 @@
 
 TEST(TestAsyncOperations, TestManagerAsync)
 {
+    // This test is built for NVIDIA 1650. It assumes:
+    // * Queue family 0 and 2 have compute capabilities
+    // * GPU is able to process parallel shader code across different families
     uint32_t size = 10;
 
     uint32_t numParallel = 2;

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -9,7 +9,7 @@ TEST(TestAsyncOperations, TestManagerAsync)
 {
     uint32_t size = 10;
 
-    uint32_t numParallel = 6;
+    uint32_t numParallel = 2;
 
     std::string shader(R"(
         #version 450
@@ -83,7 +83,7 @@ TEST(TestAsyncOperations, TestManagerAsync)
         EXPECT_EQ(inputsSyncB[i]->data(), resultSync);
     }
 
-    kp::Manager mgrAsync(0, numParallel);
+    kp::Manager mgrAsync(0, {0, 2});
 
     std::vector<std::shared_ptr<kp::Tensor>> inputsAsyncA;
     std::vector<std::shared_ptr<kp::Tensor>> inputsAsyncB;
@@ -109,6 +109,8 @@ TEST(TestAsyncOperations, TestManagerAsync)
           std::vector<char>(shader.begin(), shader.end()));
     }
 
+    // TODO: Add function to print device details (or link)
+    // TODO: Seems to fail if await called twice
     for (uint32_t i = 0; i < numParallel; i++) {
         mgrAsync.evalOpAwait("async" + std::to_string(i));
     }
@@ -122,6 +124,6 @@ TEST(TestAsyncOperations, TestManagerAsync)
         EXPECT_EQ(inputsAsyncB[i]->data(), resultAsync);
     }
 
-    SPDLOG_ERROR("Total Sync: {}", durationSync);
-    SPDLOG_ERROR("Total Async: {}", durationAsync);
+    // The speedup should be at least 40% 
+    EXPECT_LT(durationAsync, durationSync * 0.6);
 }

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -1,0 +1,95 @@
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+
+#include "kompute/Kompute.hpp"
+
+TEST(TestAsyncOperations, TestManagerAsync)
+{
+    uint32_t size = 100000;
+
+    std::vector<float> data(size, 0.0);
+    std::vector<float> resultSync(size, 100000);
+    std::vector<float> resultAsync(size, 200000);
+
+    std::shared_ptr<kp::Tensor> tensorA{ new kp::Tensor(data) };
+    std::shared_ptr<kp::Tensor> tensorB{ new kp::Tensor(data) };
+    std::shared_ptr<kp::Tensor> tensorC{ new kp::Tensor(data) };
+    std::shared_ptr<kp::Tensor> tensorD{ new kp::Tensor(data) };
+    std::shared_ptr<kp::Tensor> tensorE{ new kp::Tensor(data) };
+    std::shared_ptr<kp::Tensor> tensorF{ new kp::Tensor(data) };
+
+    kp::Manager mgr;
+
+    mgr.evalOpDefault<kp::OpTensorCreate>({ tensorA, tensorB, tensorC, tensorD, tensorE, tensorF });
+
+    std::string shader(R"(
+        #version 450
+
+        layout (local_size_x = 1) in;
+
+        layout(set = 0, binding = 0) buffer a { float pa[]; };
+        layout(set = 0, binding = 1) buffer b { float pb[]; };
+
+        void main() {
+            uint index = gl_GlobalInvocationID.x;
+
+            for (int i = 0; i < 100000; i++)
+            {
+                pa[index] += 1.0;
+            }
+
+            pb[index] = pa[index];
+        }
+    )");
+
+    auto startSync = std::chrono::high_resolution_clock::now();
+
+    mgr.evalOpDefault<kp::OpAlgoBase<>>(
+      { tensorA, tensorB }, std::vector<char>(shader.begin(), shader.end()));
+
+    mgr.evalOpDefault<kp::OpAlgoBase<>>(
+      { tensorC, tensorD }, std::vector<char>(shader.begin(), shader.end()));
+
+    mgr.evalOpDefault<kp::OpAlgoBase<>>(
+      { tensorE, tensorF }, std::vector<char>(shader.begin(), shader.end()));
+
+    auto endSync = std::chrono::high_resolution_clock::now();
+
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensorB, tensorD, tensorF });
+
+    EXPECT_EQ(tensorB->data(), resultSync);
+    EXPECT_EQ(tensorD->data(), resultSync);
+    EXPECT_EQ(tensorF->data(), resultSync);
+
+    auto durationSync = std::chrono::duration_cast<std::chrono::microseconds>(endSync - startSync).count();
+
+    auto startAsync = std::chrono::high_resolution_clock::now();
+
+    mgr.evalOpAsync<kp::OpAlgoBase<>>(
+      { tensorA, tensorB }, "asyncOne", std::vector<char>(shader.begin(), shader.end()));
+
+    mgr.evalOpAsync<kp::OpAlgoBase<>>(
+      { tensorC, tensorD }, "asyncTwo", std::vector<char>(shader.begin(), shader.end()));
+
+    mgr.evalOpAsync<kp::OpAlgoBase<>>(
+      { tensorE, tensorF }, "asyncThree", std::vector<char>(shader.begin(), shader.end()));
+
+    mgr.evalOpAwait("asyncOne");
+    mgr.evalOpAwait("asyncTwo");
+    mgr.evalOpAwait("asyncThree");
+
+    auto endAsync = std::chrono::high_resolution_clock::now();
+
+    auto durationAsync = std::chrono::duration_cast<std::chrono::microseconds>(endAsync - startAsync).count();
+
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensorB, tensorD, tensorF });
+
+    EXPECT_EQ(tensorB->data(), resultAsync);
+    EXPECT_EQ(tensorD->data(), resultAsync);
+    EXPECT_EQ(tensorF->data(), resultAsync);
+
+    SPDLOG_DEBUG("Total Sync: {}", durationSync);
+    SPDLOG_DEBUG("Total Async: {}", durationAsync);
+}

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -7,7 +7,7 @@
 
 TEST(TestAsyncOperations, TestManagerAsync)
 {
-    uint32_t size = 100000;
+    uint32_t size = 10;
 
     uint32_t numParallel = 6;
 
@@ -19,22 +19,38 @@ TEST(TestAsyncOperations, TestManagerAsync)
         layout(set = 0, binding = 0) buffer a { float pa[]; };
         layout(set = 0, binding = 1) buffer b { float pb[]; };
 
+        shared uint sharedTotal[1];
+
         void main() {
             uint index = gl_GlobalInvocationID.x;
 
-            for (int i = 0; i < 10000; i++)
+            sharedTotal[0] = 0;
+
+            barrier();
+            memoryBarrierShared();
+
+            for (int i = 0; i < 100000000; i++)
             {
-                pa[index] += 1.0;
+                atomicAdd(sharedTotal[0], 1);
+                atomicAdd(sharedTotal[0], -1);
+                atomicAdd(sharedTotal[0], 1);
+                atomicAdd(sharedTotal[0], -1);
+                atomicAdd(sharedTotal[0], 1);
+                atomicAdd(sharedTotal[0], -1);
+                atomicAdd(sharedTotal[0], 1);
             }
 
-            pb[index] = pa[index];
+            barrier();
+            memoryBarrierShared();
+
+            pb[index] = sharedTotal[0];
             pa[index] = 0;
         }
     )");
 
     std::vector<float> data(size, 0.0);
-    std::vector<float> resultSync(size, 10000);
-    std::vector<float> resultAsync(size, 10000);
+    std::vector<float> resultSync(size, 100000000);
+    std::vector<float> resultAsync(size, 100000000);
 
     kp::Manager mgr;
 
@@ -58,10 +74,10 @@ TEST(TestAsyncOperations, TestManagerAsync)
 
     }
 
-    mgr.evalOpDefault<kp::OpTensorSyncLocal>(inputsSyncB);
-
     auto endSync = std::chrono::high_resolution_clock::now();
     auto durationSync = std::chrono::duration_cast<std::chrono::microseconds>(endSync - startSync).count();
+
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>(inputsSyncB);
 
     for (uint32_t i = 0; i < numParallel; i++) {
         EXPECT_EQ(inputsSyncB[i]->data(), resultSync);
@@ -97,10 +113,10 @@ TEST(TestAsyncOperations, TestManagerAsync)
         mgrAsync.evalOpAwait("async" + std::to_string(i));
     }
 
-    mgrAsync.evalOpDefault<kp::OpTensorSyncLocal>({ inputsAsyncB });
-
     auto endAsync = std::chrono::high_resolution_clock::now();
     auto durationAsync = std::chrono::duration_cast<std::chrono::microseconds>(endAsync - startAsync).count();
+
+    mgrAsync.evalOpDefault<kp::OpTensorSyncLocal>({ inputsAsyncB });
 
     for (uint32_t i = 0; i < numParallel; i++) {
         EXPECT_EQ(inputsAsyncB[i]->data(), resultAsync);

--- a/test/TestAsyncOperations.cpp
+++ b/test/TestAsyncOperations.cpp
@@ -72,13 +72,14 @@ TEST(TestAsyncOperations, TestManagerAsync)
 
     for (uint32_t i = 0; i < numParallel; i++) {
         mgr.evalOpDefault<kp::OpAlgoBase<>>(
-          { inputsSyncA[i],  inputsSyncB[i] }, 
+          { inputsSyncA[i], inputsSyncB[i] },
           std::vector<char>(shader.begin(), shader.end()));
-
     }
 
     auto endSync = std::chrono::high_resolution_clock::now();
-    auto durationSync = std::chrono::duration_cast<std::chrono::microseconds>(endSync - startSync).count();
+    auto durationSync =
+      std::chrono::duration_cast<std::chrono::microseconds>(endSync - startSync)
+        .count();
 
     mgr.evalOpDefault<kp::OpTensorSyncLocal>(inputsSyncB);
 
@@ -86,7 +87,7 @@ TEST(TestAsyncOperations, TestManagerAsync)
         EXPECT_EQ(inputsSyncB[i]->data(), resultSync);
     }
 
-    kp::Manager mgrAsync(0, {0, 2});
+    kp::Manager mgrAsync(0, { 0, 2 });
 
     std::vector<std::shared_ptr<kp::Tensor>> inputsAsyncA;
     std::vector<std::shared_ptr<kp::Tensor>> inputsAsyncB;
@@ -107,8 +108,8 @@ TEST(TestAsyncOperations, TestManagerAsync)
 
     for (uint32_t i = 0; i < numParallel; i++) {
         mgrAsync.evalOpAsync<kp::OpAlgoBase<>>(
-          { inputsAsyncA[i], inputsAsyncB[i] }, 
-          "async" + std::to_string(i), 
+          { inputsAsyncA[i], inputsAsyncB[i] },
+          "async" + std::to_string(i),
           std::vector<char>(shader.begin(), shader.end()));
     }
 
@@ -117,7 +118,9 @@ TEST(TestAsyncOperations, TestManagerAsync)
     }
 
     auto endAsync = std::chrono::high_resolution_clock::now();
-    auto durationAsync = std::chrono::duration_cast<std::chrono::microseconds>(endAsync - startAsync).count();
+    auto durationAsync = std::chrono::duration_cast<std::chrono::microseconds>(
+                           endAsync - startAsync)
+                           .count();
 
     mgrAsync.evalOpDefault<kp::OpTensorSyncLocal>({ inputsAsyncB });
 
@@ -128,6 +131,6 @@ TEST(TestAsyncOperations, TestManagerAsync)
     SPDLOG_ERROR("sync {}", durationSync);
     SPDLOG_ERROR("async {}", durationAsync);
 
-    // The speedup should be at least 40% 
+    // The speedup should be at least 40%
     EXPECT_LT(durationAsync, durationSync * 0.6);
 }

--- a/test/TestMultipleAlgoExecutions.cpp
+++ b/test/TestMultipleAlgoExecutions.cpp
@@ -258,10 +258,10 @@ TEST(TestMultipleAlgoExecutions, ManagerEvalMultSourceStrOpCreate)
       )");
 
     mgr.evalOpDefault<kp::OpAlgoBase<>>(
-            { tensorInA, tensorInB, tensorOut },
-            std::vector<char>(shader.begin(), shader.end()));
+      { tensorInA, tensorInB, tensorOut },
+      std::vector<char>(shader.begin(), shader.end()));
 
-    mgr.evalOpDefault<kp::OpTensorSyncLocal>({tensorOut});
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensorOut });
 
     EXPECT_EQ(tensorOut->data(), std::vector<float>({ 0.0, 4.0, 12.0 }));
 }
@@ -295,10 +295,10 @@ TEST(TestMultipleAlgoExecutions, ManagerEvalMultSourceStrMgrCreate)
       )");
 
     mgr.evalOpDefault<kp::OpAlgoBase<>>(
-            { tensorInA, tensorInB, tensorOut },
-            std::vector<char>(shader.begin(), shader.end()));
+      { tensorInA, tensorInB, tensorOut },
+      std::vector<char>(shader.begin(), shader.end()));
 
-    mgr.evalOpDefault<kp::OpTensorSyncLocal>({tensorOut});
+    mgr.evalOpDefault<kp::OpTensorSyncLocal>({ tensorOut });
 
     EXPECT_EQ(tensorOut->data(), std::vector<float>({ 0.0, 4.0, 12.0 }));
 }


### PR DESCRIPTION
Fixes #51 

This PR contains:
* Kompute Manager now can be initialized with multiple queues
* Sequence can now be created with explicitly provided queue
* Evaluation commands can be executed asynchonously with Async/Await
* Contains test that evaluates performance of synchronous vs asynchronous through simple benchmark
* Adds extra documentation on the topic
