### PR TITLE
Add link to official Vulkan website to download the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Given Kompute is expected to be used across a broad range of architectures and h
 
 #### Required dependencies
 
-The only required dependency in the build is Vulkan. More specifically, the header files vulkan.h and vulkan.hpp, which are both part of the Vulkan SDK. If you haven't installed the Vulkan SDK yet, you can [download it here](https://www.lunarg.com/vulkan-sdk/).
+The only required dependency in the build is Vulkan. More specifically, the header files vulkan.h and vulkan.hpp, which are both part of the Vulkan SDK. If you haven't installed the Vulkan SDK yet, you can [download it here](https://vulkan.lunarg.com/).
 
 #### Optional dependencies
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Given Kompute is expected to be used across a broad range of architectures and h
 
 #### Required dependencies
 
-The only required dependency in the build is Vulkan (vulkan.h and vulkan.hpp which are both part of the Vulkan SDK).
+The only required dependency in the build is Vulkan. More specifically, the header files vulkan.h and vulkan.hpp, which are both part of the Vulkan SDK. If you haven't installed the Vulkan SDK yet, you can [download it here](https://www.lunarg.com/vulkan-sdk/).
 
 #### Optional dependencies
 


### PR DESCRIPTION
This prevents new developers, who might not have actually worked with Vulkan (but want to work with Kompute), from having to do the extra step in googling the SDK download page. This reduces friction for potential new developers.