### PR TITLE
String parameter for eval_algo_str methods in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ mgr.eval_algo_data_def(
 
 # Alternatively can pass raw string/bytes:
 # shaderFileData = """ shader code here... """
-# mgr.eval_algo_data_def([tensor_in_a, tensor_in_b, tensor_out], list(shaderFileData))
+# mgr.eval_algo_data_def([tensor_in_a, tensor_in_b, tensor_out], shaderFileData)
 
 mgr.eval_await_def()
 

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -164,6 +164,13 @@ PYBIND11_MODULE(kp, m) {
             "Evaluates an operation using a custom shader provided from a shader path with new anonymous Sequence")
         .def("eval_algo_str_def", &kp::Manager::evalOpDefault<kp::OpAlgoBase, std::vector<char>>,
             "Evaluates an operation using a custom shader provided as string provided as list of characters with new anonymous Sequence")
+        .def("eval_algo_str_def", [](kp::Manager &self,
+                                     std::vector<std::shared_ptr<kp::Tensor>> tensors,
+                                     const std::string& shader_str){
+                const std::vector<char> shader_vec(shader_str.begin(), shader_str.end());
+                self.evalOpDefault<kp::OpAlgoBase>(tensors, shader_vec);
+        },
+            "Evaluates an operation using a custom shader provided as string with a new anonymous Sequence")
         .def("eval_algo_data_def", [](kp::Manager &self,
                                     std::vector<std::shared_ptr<kp::Tensor>> tensors,
                                     py::bytes &bytes) {
@@ -193,6 +200,14 @@ PYBIND11_MODULE(kp, m) {
             "Evaluates an operation using a custom shader provided from a shader path with explicitly named Sequence")
         .def("eval_algo_str", &kp::Manager::evalOp<kp::OpAlgoBase, std::vector<char>>,
             "Evaluates an operation using a custom shader provided as string provided as list of characters with explicitly named Sequence")
+        .def("eval_algo_str", [](kp::Manager &self,
+                                    std::vector<std::shared_ptr<kp::Tensor>> tensors,
+                                    const std::string& sequenceName,
+                                    const std::string& shader_str) {
+                const std::vector<char> shader_vec(shader_str.begin(), shader_str.end());
+                self.evalOp<kp::OpAlgoBase>(tensors, sequenceName, shader_vec);
+            },
+            "Evaluates an operation using a custom shader provided as string with explicitly named Sequence")
         .def("eval_algo_data", [](kp::Manager &self,
                                     std::vector<std::shared_ptr<kp::Tensor>> tensors,
                                     std::string sequenceName,
@@ -224,6 +239,13 @@ PYBIND11_MODULE(kp, m) {
             "Evaluates asynchronously an operation using a custom shader provided from a shader path with anonymous Sequence")
         .def("eval_async_algo_str_def", &kp::Manager::evalOpAsyncDefault<kp::OpAlgoBase, std::vector<char>>,
             "Evaluates Asynchronously an operation using a custom shader provided as string provided as list of characters with new anonymous Sequence")
+        .def("eval_async_algo_str_def", [](kp::Manager &self,
+                                           std::vector<std::shared_ptr<kp::Tensor>> tensors,
+                                           const std::string& shader_str) {
+                const std::vector<char> shader_vec(shader_str.begin(), shader_str.end());
+                self.evalOpAsyncDefault<kp::OpAlgoBase>(tensors, shader_vec);
+            },
+            "Evaluates Asynchronously an operation using a custom shader provided as string with new anonymous Sequence")
         .def("eval_async_algo_data_def", [](kp::Manager &self,
                                     std::vector<std::shared_ptr<kp::Tensor>> tensors,
                                     py::bytes &bytes) {
@@ -253,6 +275,14 @@ PYBIND11_MODULE(kp, m) {
             "Evaluates asynchronously an operation using a custom shader provided from a shader path with explicitly named Sequence")
         .def("eval_async_algo_str", &kp::Manager::evalOpAsync<kp::OpAlgoBase, std::vector<char>>,
             "Evaluates Asynchronous an operation using a custom shader provided as string provided as list of characters with explicitly named Sequence")
+        .def("eval_async_algo_str", [](kp::Manager &self,
+                                    std::vector<std::shared_ptr<kp::Tensor>> tensors,
+                                    const std::string& sequenceName,
+                                    const std::string& shader_str) {
+                const std::vector<char> shader_vec(shader_str.begin(), shader_str.end());
+                self.evalOpAsync<kp::OpAlgoBase>(tensors, sequenceName, shader_vec);
+            },
+            "Evaluates Asynchronous an operation using a custom shader provided as string with explicitly named Sequence")
         .def("eval_async_algo_data", [](kp::Manager &self,
                                     std::vector<std::shared_ptr<kp::Tensor>> tensors,
                                     std::string sequenceName,

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -54,7 +54,7 @@ def test_opalgobase_data():
 
     mgr.eval_tensor_create_def([tensor_in_a, tensor_in_b, tensor_out])
 
-    mgr.eval_algo_str_def([tensor_in_a, tensor_in_b, tensor_out], list(shaderData))
+    mgr.eval_algo_str_def([tensor_in_a, tensor_in_b, tensor_out], shaderData)
 
     mgr.eval_tensor_sync_local_def([tensor_out])
 


### PR DESCRIPTION
Added string parameters for all `eval_algo_str` methods as described in #93 . I have kept the previous methods that accept lists but I guess they are redundant now? Shall I remove them?