### PR TITLE
Ubuntu CI

### DIFF
--- a/.github/workflows/cpp_ubuntu.yml
+++ b/.github/workflows/cpp_ubuntu.yml
@@ -2,9 +2,9 @@ name: C++ Ubuntu
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build-ubuntu:

--- a/.github/workflows/cpp_ubuntu.yml
+++ b/.github/workflows/cpp_ubuntu.yml
@@ -1,0 +1,42 @@
+name: C++ Ubuntu
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install libvulkan-dev
+        #swiftshader vulkan cpu implementation
+        sudo wget https://www.dropbox.com/s/d0weho6l8dovm71/libvk_swiftshader.so?dl=1 -O /usr/lib/libvk_swiftshader.so
+        sudo mkdir -p /usr/share/vulkan/icd.d
+        sudo wget https://www.dropbox.com/s/5oly49ev3vvcfdu/vk_swiftshader_icd.json?dl=1 -O /usr/share/vulkan/icd.d/vk_swiftshader_icd.json
+    - name: configure
+      run: |
+        cmake . -Bbuild/ \
+                  -DKOMPUTE_OPT_BUILD_TESTS=1                \
+                  -DKOMPUTE_OPT_INSTALL=1                    \
+                  -DKOMPUTE_OPT_ENABLE_SPDLOG=1              \
+                  -DSPDLOG_INSTALL=1                         \
+                  -DKOMPUTE_OPT_REPO_SUBMODULE_BUILD=1       \
+                  -DKOMPUTE_OPT_BUILD_TESTS=1
+    - name: build
+      run: | 
+        make -C build/ -j
+    - name: tests
+      run: |
+        #only running tests that dont require GLSL compilation
+        ./build/test/test_kompute --gtest_filter=*Tensor*
+        ./build/test/test_kompute --gtest_filter=TestManager*
+        


### PR DESCRIPTION
Basic CI for Ubuntu including (partial) tests as discussed in #114.
This uses Swiftshader CPU implementation as Vulkan ICD. The precompiled binaries are downloaded from Dropbox, for a long term solution you might want to store them somewhere else. 
Only tests that don't require GLSL are run because Swiftshader does not support it.