### PR TITLE
Workgroups for Python

### DIFF
--- a/src/OpAlgoBase.cpp
+++ b/src/OpAlgoBase.cpp
@@ -25,7 +25,7 @@ OpAlgoBase::OpAlgoBase(std::shared_ptr<vk::PhysicalDevice> physicalDevice,
         // If at least the x value is provided we use mainly the parameters
         // provided
         this->mKomputeWorkgroup = {
-            0,
+            komputeWorkgroup.x,
             komputeWorkgroup.y > 0 ? komputeWorkgroup.y : 1,
             komputeWorkgroup.z > 0 ? komputeWorkgroup.z : 1
         };


### PR DESCRIPTION
- bugfix for custom workgroups in C++ (OpAlgoBase.cpp:28)
- added workgroup argument for` Sequence.record_algo*` + test case
- Merged both `Tensor` constructors and it now also accepts numpy arrays