### PR TITLE
Disallowing zero sized tensors

### DIFF
--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -268,10 +268,14 @@ Tensor::createBuffer()
         throw std::runtime_error("Kompute Tensor device is null");
     }
 
-    this->mFreeBuffer = true;
 
     vk::BufferUsageFlags usageFlags = this->getBufferUsageFlags();
     vk::DeviceSize bufferSize = this->memorySize();
+    if(bufferSize<1){
+        throw std::runtime_error("Kompute Tensor attempted to create a zero-sized buffer");
+    }
+    
+    this->mFreeBuffer = true;
 
     SPDLOG_DEBUG("Kompute Tensor creating buffer with memory size: {}, and "
                  "usage flags: {}",

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -39,7 +39,7 @@ class Tensor
      *  Default constructor with data provided which would be used to create the
      * respective vulkan buffer and memory.
      *
-     *  @param data Vector of data that will be used by the tensor
+     *  @param data Non-zero-sized vector of data that will be used by the tensor
      *  @param tensorType Type for the tensor which is of type TensorTypes
      */
     Tensor(const std::vector<float>& data,

--- a/test/TestOpTensorCreate.cpp
+++ b/test/TestOpTensorCreate.cpp
@@ -113,3 +113,21 @@ TEST(TestOpTensorCreate, NoErrorIfTensorFreedBefore)
     EXPECT_FALSE(tensorA->isInit());
     EXPECT_FALSE(tensorB->isInit());
 }
+
+
+TEST(TestOpTensorCreate, ExceptionOnZeroSizeTensor)
+{
+    std::vector<float> testVecA;
+
+    std::shared_ptr<kp::Tensor> tensorA{ new kp::Tensor(testVecA) };
+
+    kp::Manager mgr;
+
+    try{
+        mgr.evalOpDefault<kp::OpTensorCreate>({ tensorA });
+    } catch( const std::runtime_error& err ) {
+         // check exception
+        ASSERT_STREQ("Kompute Tensor attempted to create a zero-sized buffer", err.what() );
+    }
+
+}

--- a/test/TestOpTensorCreate.cpp
+++ b/test/TestOpTensorCreate.cpp
@@ -127,7 +127,7 @@ TEST(TestOpTensorCreate, ExceptionOnZeroSizeTensor)
         mgr.evalOpDefault<kp::OpTensorCreate>({ tensorA });
     } catch( const std::runtime_error& err ) {
          // check exception
-        ASSERT_STREQ("Kompute Tensor attempted to create a zero-sized buffer", err.what() );
+        ASSERT_TRUE( std::string(err.what()).find("zero-sized") != std::string::npos );
     }
 
 }


### PR DESCRIPTION
Vulkan specs [disallow zero-sized buffers](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferCreateInfo.html). I've run into segfaults accidentally trying to create some and this was mentioned in #14.
I've added an exception with an error message for easier fault finding. The exception is thrown right before buffer creation because that's where the segfault would happen, but one might consider throwing it already in the constructor.