### PR TITLE
Sharing mData between device and staging tensors

### DIFF
--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -741,6 +741,26 @@ class Tensor
      */
     Tensor(const std::vector<float>& data,
            TensorTypes tensorType = TensorTypes::eDevice);
+    
+    /**
+     * Constructor with a shared pointer to data provided which would be used to create the
+     * respective vulkan buffer and memory.
+     *
+     *  @param data Shared pointer to a non-zero-sized vector of data that will be used by the tensor
+     *  @param tensorType Type for the tensor which is of type TensorTypes
+     */
+    Tensor(const std::shared_ptr<std::vector<float>>& data,
+           TensorTypes tensorType = TensorTypes::eDevice);
+
+    /**
+     * Constructor with an initializer list which would be used to create the
+     * respective vulkan buffer and memory.
+     *
+     *  @param data Shared pointer to a non-zero-sized vector of data that will be used by the tensor
+     *  @param tensorType Type for the tensor which is of type TensorTypes
+     */
+    Tensor(std::initializer_list<float> data,
+           TensorTypes tensorType = TensorTypes::eDevice);
 
     /**
      * Destructor which is in charge of freeing vulkan resources unless they
@@ -771,6 +791,17 @@ class Tensor
      * tensor.
      */
     std::vector<float>& data();
+
+    /**
+     * Returns a shared pointer to the vector of data currently contained 
+     * by the Tensor. It is important to ensure that there is no out-of-sync
+     * data with the GPU memory.
+     *
+     * @return Reference to vector of elements representing the data in the
+     * tensor.
+     */
+    std::shared_ptr<std::vector<float>> data_sp();
+
     /**
      * Overrides the subscript operator to expose the underlying data's
      * subscript operator which in this case would be its underlying
@@ -875,8 +906,9 @@ class Tensor
     std::shared_ptr<vk::DeviceMemory> mMemory;
     bool mFreeMemory;
 
+    std::shared_ptr<std::vector<float>> mData;
+
     // -------------- ALWAYS OWNED RESOURCES
-    std::vector<float> mData;
 
     TensorTypes mTensorType = TensorTypes::eDevice;
 

--- a/src/OpTensorCreate.cpp
+++ b/src/OpTensorCreate.cpp
@@ -44,7 +44,7 @@ OpTensorCreate::init()
             tensor->init(this->mPhysicalDevice, this->mDevice);
 
             std::shared_ptr<Tensor> stagingTensor = std::make_shared<Tensor>(
-              tensor->data(), Tensor::TensorTypes::eStaging);
+              tensor->data_sp(), Tensor::TensorTypes::eStaging);
 
             stagingTensor->init(this->mPhysicalDevice, this->mDevice);
 

--- a/src/OpTensorSyncDevice.cpp
+++ b/src/OpTensorSyncDevice.cpp
@@ -49,7 +49,7 @@ OpTensorSyncDevice::init()
         if (tensor->tensorType() == Tensor::TensorTypes::eDevice) {
 
             std::shared_ptr<Tensor> stagingTensor = std::make_shared<Tensor>(
-              tensor->data(), Tensor::TensorTypes::eStaging);
+              tensor->data_sp(), Tensor::TensorTypes::eStaging);
 
             stagingTensor->init(this->mPhysicalDevice, this->mDevice);
 

--- a/src/OpTensorSyncLocal.cpp
+++ b/src/OpTensorSyncLocal.cpp
@@ -49,7 +49,7 @@ OpTensorSyncLocal::init()
         if (tensor->tensorType() == Tensor::TensorTypes::eDevice) {
 
             std::shared_ptr<Tensor> stagingTensor = std::make_shared<Tensor>(
-              tensor->data(), Tensor::TensorTypes::eStaging);
+              tensor->data_sp(), Tensor::TensorTypes::eStaging);
 
             stagingTensor->init(this->mPhysicalDevice, this->mDevice);
 

--- a/src/include/kompute/Tensor.hpp
+++ b/src/include/kompute/Tensor.hpp
@@ -44,6 +44,28 @@ class Tensor
      */
     Tensor(const std::vector<float>& data,
            TensorTypes tensorType = TensorTypes::eDevice);
+    
+    /**
+     * Constructor with a shared pointer to data provided which would be used to create the
+     * respective vulkan buffer and memory.
+     *
+     *  @param data Shared pointer to a non-zero-sized vector of data that will be used by the tensor
+     *  @param tensorType Type for the tensor which is of type TensorTypes
+     */
+    Tensor(const std::shared_ptr<std::vector<float>>& data,
+           TensorTypes tensorType = TensorTypes::eDevice);
+
+
+    /**
+     * Constructor with an initializer list which would be used to create the
+     * respective vulkan buffer and memory.
+     *
+     *  @param data Shared pointer to a non-zero-sized vector of data that will be used by the tensor
+     *  @param tensorType Type for the tensor which is of type TensorTypes
+     */
+    Tensor(std::initializer_list<float> data,
+           TensorTypes tensorType = TensorTypes::eDevice);
+
 
     /**
      * Destructor which is in charge of freeing vulkan resources unless they
@@ -74,6 +96,17 @@ class Tensor
      * tensor.
      */
     std::vector<float>& data();
+
+    /**
+     * Returns a shared pointer to the vector of data currently contained 
+     * by the Tensor. It is important to ensure that there is no out-of-sync
+     * data with the GPU memory.
+     *
+     * @return Reference to vector of elements representing the data in the
+     * tensor.
+     */
+    std::shared_ptr<std::vector<float>> data_sp();
+
     /**
      * Overrides the subscript operator to expose the underlying data's
      * subscript operator which in this case would be its underlying
@@ -178,8 +211,9 @@ class Tensor
     std::shared_ptr<vk::DeviceMemory> mMemory;
     bool mFreeMemory;
 
+    std::shared_ptr<std::vector<float>> mData;
+
     // -------------- ALWAYS OWNED RESOURCES
-    std::vector<float> mData;
 
     TensorTypes mTensorType = TensorTypes::eDevice;
 


### PR DESCRIPTION
Currently, when creating a tensor the data is copied several times:

- in the `Tensor` constructor
- in `OpTensorCreate` when creating a staged tensor
- the staged tensor additionally allocates a host-side vulkan buffer to copy the data into

Optionally for input/output tensors:
- in `OpTensorSyncDevice`/`OpTensorSyncLocal` when creating another staged tensor
- which creates another host-side vulkan buffer

This is 5x the required memory. Additionally, those staging tensors are not destroyed because sequences are never deleted (#36) which creates a memory leak. This is unacceptable when working with large amounts of data. It has already happened that I've run out of host memory several times.

To mitigate this, I've converted `Tensor::mData` from `std::vector` to a `std::shared_ptr<std::vector>` to enable sharing the data between device tensors and staging tensors to reduce memory footprint a little.
In the long term larger refactoring is needed (esp. #36 and #14)