### PR TITLE
Adding test code coverage using gcov and lcov

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,17 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE=1 ${KOMPUTE_EX
 
 if(KOMPUTE_OPT_CODE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage --coverage")
+
+    set(CODECOV_DIR
+        ${CMAKE_CURRENT_BINARY_DIR}/codecov/)
+    set(CODECOV_DIR_LCOV
+        ${CODECOV_DIR}lcov/)
+    set(CODECOV_FILENAME_LCOV_INFO
+        lcov.info)
+    set(CODECOV_FILENAME_LCOV_INFO_FULL
+        lcov_full.info)
+    set(CODECOV_DIR_HTML
+        ${CODECOV_DIR}html/)
 endif()
 
 # Allow scripts to call main kompute Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 # Enable or disable targets
 option(KOMPUTE_OPT_BUILD_TESTS "Enable if you want to build tests" 0)
+option(KOMPUTE_OPT_CODE_COVERAGE "Enable if you want code coverage" 0)
 option(KOMPUTE_OPT_BUILD_DOCS "Enable if you want to build documentation" 0)
 option(KOMPUTE_OPT_BUILD_SHADERS "Enable if you want to re-build all shader files" 0)
 option(KOMPUTE_OPT_BUILD_SINGLE_HEADER "Enable if you want to build the single header file" 0)
@@ -40,6 +41,10 @@ endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG=1 ${KOMPUTE_EXTRA_CXX_FLAGS} -DUSE_DEBUG_EXTENTIONS")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DRELEASE=1 ${KOMPUTE_EXTRA_CXX_FLAGS}")
+
+if(KOMPUTE_OPT_CODE_COVERAGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage --coverage")
+endif()
 
 # Allow scripts to call main kompute Makefile
 function(kompute_make KOMPUTE_MAKE_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ mk_cmake:
 		-DKOMPUTE_OPT_BUILD_SINGLE_HEADER=1 \
 		-DKOMPUTE_OPT_ENABLE_SPDLOG=1 \
 		-DSPDLOG_INSTALL=1 \
+		-DKOMPUTE_OPT_CODE_COVERAGE=1 \
 		-G "Unix Makefiles"
 
 mk_build_all:

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,9 @@ generate_python_docstrings:
 install_python_reqs:
 	python3 -m pip install -r scripts/requirements.txt
 
+install_lcov:
+	sudo apt install lcov -y
+
 build_shaders:
 	python3 scripts/convert_shaders.py \
 		--shader-path shaders/glsl \

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -21,6 +21,8 @@ set(DOXYFILE_IN
     ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
 set(DOXYFILE_OUT
     ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+set(CODECOV_INDEX_FILE
+    ${DOXYGEN_OUTPUT_DIR/html/codecov/index.html})
 
 # Perform replacement with cmake vars inside Doxifine.in
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
@@ -33,8 +35,13 @@ add_custom_command(
     COMMENT "Generating docs"
 )
 
-add_custom_target(gendoxygen ALL 
-    DEPENDS ${DOXYGEN_INDEX_FILE})
+if(KP_OPT_DOCS_GEN_CODECOV)
+    add_custom_target(gendoxygen ALL 
+        DEPENDS ${DOXYGEN_INDEX_FILE} ${DOXYGEN_OUTPUT_DIR})
+else()
+    add_custom_target(gendoxygen ALL 
+        DEPENDS ${DOXYGEN_INDEX_FILE})
+endif()
 
 
 #####################################################

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -21,8 +21,14 @@ set(DOXYFILE_IN
     ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
 set(DOXYFILE_OUT
     ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-set(CODECOV_INDEX_FILE
-    ${DOXYGEN_OUTPUT_DIR/html/codecov/index.html})
+set(SPHINX_SOURCE
+    ${CMAKE_CURRENT_SOURCE_DIR})
+set(SPHINX_BUILD
+    ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
+set(CODECOV_DOCS_DIR
+    ${SPHINX_BUILD}/codecov/)
+set(CODECOV_DOCS_INDEX_FILE
+    ${CODECOV_DOCS_DIR}/index.html})
 
 # Perform replacement with cmake vars inside Doxifine.in
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
@@ -35,23 +41,31 @@ add_custom_command(
     COMMENT "Generating docs"
 )
 
-if(KP_OPT_DOCS_GEN_CODECOV)
+if(KOMPUTE_OPT_CODE_COVERAGE)
     add_custom_target(gendoxygen ALL 
-        DEPENDS ${DOXYGEN_INDEX_FILE} ${DOXYGEN_OUTPUT_DIR})
+        DEPENDS ${DOXYGEN_INDEX_FILE} ${CODECOV_DOCS_INDEX_FILE})
 else()
     add_custom_target(gendoxygen ALL 
         DEPENDS ${DOXYGEN_INDEX_FILE})
 endif()
 
+#####################################################
+########### CODECOV DOCS ###############
+#####################################################
+
+add_custom_command(
+    OUTPUT ${CODECOV_DOCS_INDEX_FILE}
+    COMMAND ${CMAKE_COMMAND}
+        -E copy_directory
+        ${CODECOV_DIR_HTML}
+        ${CODECOV_DOCS_DIR}
+    DEPENDS codecov_genhtml)
 
 #####################################################
 ########### Sphinx ###############
 #####################################################
 
 find_package(Sphinx REQUIRED)
-
-set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
-set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
 
 add_custom_target(gensphinx ALL
     COMMAND

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Documentation Index (as per sidebar)
     C++ Converting GLSL/HLSL Shaders to Cpp Headers <overview/shaders-to-headers>
     C++ Extending Kompute with Custom Operations <overview/custom-operations>
     C++ Class Documentation & Reference <overview/reference>
+    C++ Code Coverage <https://kompute.cc/codecov/>
 
 .. toctree::
     :titlesonly:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,4 +35,57 @@ target_link_libraries(test_kompute PRIVATE kompute)
 
 add_test(NAME test_kompute COMMAND test_kompute)
 
+#####################################################
+#################### CODECOV  #######################
+#####################################################
+
+if (KOMPUTE_OPT_CODE_COVERAGE)
+    if(NOT UNIX)
+        message(
+            FATAL_ERROR
+            "KOMPUTE_OPT_CODE_COVERAGE can only be enabled in unix based systems due to limitation on gcov")
+    endif()
+
+    add_custom_target(codecov_run_tests
+        COMMAND make -C ${PROJECT_SOURCE_DIR} mk_run_tests
+        DEPENDS test_kompute)
+
+    add_custom_target(codecov_copy_files
+        COMMAND ${CMAKE_COMMAND}
+            -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/test_kompute.dir/
+            ${CODECOV_DIR}
+        COMMAND ${CMAKE_COMMAND}
+            -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/../src/CMakeFiles/kompute.dir/
+            ${CODECOV_DIR}
+        DEPENDS test_kompute codecov_run_tests)
+
+    add_custom_target(codecov_gcov
+        COMMAND gcov
+            -b -c "*.gcno"
+        WORKING_DIRECTORY ${CODECOV_DIR}
+        DEPENDS codecov_copy_files)
+
+    add_custom_target(codecov_lcov
+        COMMAND lcov
+            --capture
+            -o ${CODECOV_FILENAME_LCOV_INFO_FULL}
+            -d .
+        COMMAND lcov
+            --extract
+            ${CODECOV_FILENAME_LCOV_INFO_FULL}
+            -o ${CODECOV_FILENAME_LCOV_INFO}
+            -d .
+            "*/src/*" "*/test/*"
+        WORKING_DIRECTORY ${CODECOV_DIR}
+        DEPENDS codecov_gcov)
+
+    add_custom_target(codecov_genhtml
+        COMMAND genhtml
+            ${CODECOV_FILENAME_LCOV_INFO}
+            --output-directory ${CODECOV_DIR_HTML}
+        WORKING_DIRECTORY ${CODECOV_DIR}
+        DEPENDS codecov_lcov)
+endif()
 


### PR DESCRIPTION
Closes #145 

Adding support for code coverage reports using `gcov` and `lcov`, as well as adding these to the documentation. 

This can be seen in the docs: https://kompute.cc/codecov/

Outstanding:
* Run codecov on full GPU codebase as currently only the CPU tests are verified given it's running on swiftshader