### PR TITLE
Too many warnings

### DIFF
--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -27,8 +27,9 @@ Sequence::~Sequence()
 {
     KP_LOG_DEBUG("Kompute Sequence Destructor started");
 
-    if (this->mDevice)
+    if (this->mDevice) {
         this->destroy();
+    }
 }
 
 void
@@ -82,8 +83,9 @@ void
 Sequence::clear()
 {
     KP_LOG_DEBUG("Kompute Sequence calling clear");
-    if (this->isRecording())
+    if (this->isRecording()) {
         this->end();
+    }
 }
 
 std::shared_ptr<Sequence>

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -27,7 +27,8 @@ Sequence::~Sequence()
 {
     KP_LOG_DEBUG("Kompute Sequence Destructor started");
 
-    this->destroy();
+    if (this->mDevice)
+        this->destroy();
 }
 
 void
@@ -81,7 +82,8 @@ void
 Sequence::clear()
 {
     KP_LOG_DEBUG("Kompute Sequence calling clear");
-    this->end();
+    if (this->isRecording())
+        this->end();
 }
 
 std::shared_ptr<Sequence>

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -28,7 +28,8 @@ Tensor::~Tensor()
     KP_LOG_DEBUG("Kompute Tensor destructor started. Type: {}",
                  this->tensorType());
 
-    this->destroy();
+    if (this->mDevice)
+        this->destroy();
 
     KP_LOG_DEBUG("Kompute Tensor destructor success");
 }

--- a/src/Tensor.cpp
+++ b/src/Tensor.cpp
@@ -28,8 +28,9 @@ Tensor::~Tensor()
     KP_LOG_DEBUG("Kompute Tensor destructor started. Type: {}",
                  this->tensorType());
 
-    if (this->mDevice)
+    if (this->mDevice) {
         this->destroy();
+    }
 
     KP_LOG_DEBUG("Kompute Tensor destructor success");
 }


### PR DESCRIPTION
When a Manager is destroyed, the Manager manually destroys Tensors and Sequences. Then the Tensor and Sequence destructors kick in and want to destroy even more, but there is nothing left to destroy so a warning is issued for every Tensor and Sequence. This is very annoying in interactive Python, esp when having a lot of Tensors.
Also, for anonymous sequences `end()` is called too often and results in another warning.

Added checks to avoid this.