### PR TITLE
Add function to list physical devices

### DIFF
--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -6,10 +6,10 @@
 
 #include "fmt/ranges.h"
 
+#include "utils.hpp"
 #include "docstrings.hpp"
 
 namespace py = pybind11;
-using namespace pybind11::literals; // for the `_a` literal
 
 //used in Core.hpp
 py::object kp_debug, kp_info, kp_warning, kp_error;
@@ -220,21 +220,18 @@ PYBIND11_MODULE(kp, m) {
             py::arg("workgroup") = kp::Workgroup(),
             py::arg("spec_consts") = kp::Constants(),
             py::arg("push_consts") = kp::Constants())
+        .def("list_devices", [](kp::Manager& self){
+            const std::vector<vk::PhysicalDevice> devices = self.listDevices();
+            py::list list;
+            for (const vk::PhysicalDevice& device : devices) {
+                list.append(kp::py::vkPropertiesToDict(device.getProperties()));
+            }
+            return list;
+        }, "Return a dict containing information about the device")
         .def("get_device_properties", [](kp::Manager& self){
-            const auto properties = self.getDeviceProperties();
-            py::dict py_props(
-                "device_name"_a = std::string(properties.deviceName.data()),
-                "max_work_group_count"_a       = py::make_tuple(properties.limits.maxComputeWorkGroupCount[0],
-                                                                properties.limits.maxComputeWorkGroupCount[1],
-                                                                properties.limits.maxComputeWorkGroupCount[2]),
-                "max_work_group_invocations"_a = properties.limits.maxComputeWorkGroupInvocations,
-                "max_work_group_size"_a        = py::make_tuple(properties.limits.maxComputeWorkGroupSize[0],
-                                                                properties.limits.maxComputeWorkGroupSize[1],
-                                                                properties.limits.maxComputeWorkGroupSize[2]),
-                "timestamps_supported"_a       = (bool)properties.limits.timestampComputeAndGraphics
-            );
+            const vk::PhysicalDeviceProperties properties = self.getDeviceProperties();
 
-            return py_props;
+            return kp::py::vkPropertiesToDict(properties);
         }, "Return a dict containing information about the device");
 
 

--- a/python/src/utils.hpp
+++ b/python/src/utils.hpp
@@ -1,0 +1,26 @@
+
+#include <kompute/Kompute.hpp>
+#include <pybind11/pybind11.h>
+
+using namespace pybind11::literals; // for the `_a` literal
+
+namespace kp {
+namespace py {
+static pybind11::dict vkPropertiesToDict(const vk::PhysicalDeviceProperties& properties) {
+
+    pybind11::dict pyDict(
+        "device_name"_a = std::string(properties.deviceName.data()),
+        "max_work_group_count"_a       = pybind11::make_tuple(properties.limits.maxComputeWorkGroupCount[0],
+                                                        properties.limits.maxComputeWorkGroupCount[1],
+                                                        properties.limits.maxComputeWorkGroupCount[2]),
+        "max_work_group_invocations"_a = properties.limits.maxComputeWorkGroupInvocations,
+        "max_work_group_size"_a        = pybind11::make_tuple(properties.limits.maxComputeWorkGroupSize[0],
+                                                        properties.limits.maxComputeWorkGroupSize[1],
+                                                        properties.limits.maxComputeWorkGroupSize[2]),
+        "timestamps_supported"_a       = (bool)properties.limits.timestampComputeAndGraphics
+    );
+
+    return pyDict;
+}
+}
+}

--- a/python/test/test_kompute.py
+++ b/python/test/test_kompute.py
@@ -227,3 +227,15 @@ def test_workgroup():
     assert np.all(tensor_a.data() == np.stack([np.arange(16)]*8, axis=1).ravel())
     assert np.all(tensor_b.data() == np.stack([np.arange(8)]*16, axis=0).ravel())
 
+def test_mgr_utils():
+    mgr = kp.Manager()
+
+    props = mgr.get_device_properties()
+
+    assert "device_name" in props
+
+    devices = mgr.list_devices()
+
+    assert len(devices) == 1
+    assert "device_name" in devices[0]
+

--- a/single_include/kompute/Kompute.hpp
+++ b/single_include/kompute/Kompute.hpp
@@ -2156,9 +2156,18 @@ class Manager
     void clear();
 
     /**
-     * Return a struct containing information about the device.
+     * Information about the current device.
+     *
+     * @return vk::PhysicalDeviceProperties containing information about the device
      **/
     vk::PhysicalDeviceProperties getDeviceProperties() const;
+
+    /**
+     * List the devices available in the current vulkan instance.
+     *
+     * @return vector of physical devices containing their respective properties
+     **/
+    std::vector<vk::PhysicalDevice> listDevices() const;
 
   private:
     // -------------- OPTIONALLY OWNED RESOURCES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,8 +51,10 @@ endif()
 
 target_include_directories(
     kompute PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${PROJECT_SOURCE_DIR}/single_include
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
+    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:single_include>
 )
 
 if(NOT KOMPUTE_OPT_ANDOID_BUILD)

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -453,4 +453,10 @@ Manager::getDeviceProperties() const
     return this->mPhysicalDevice->getProperties();
 }
 
+std::vector<vk::PhysicalDevice>
+Manager::listDevices() const
+{
+    return this->mInstance->enumeratePhysicalDevices();
+}
+
 }

--- a/src/include/kompute/Manager.hpp
+++ b/src/include/kompute/Manager.hpp
@@ -154,9 +154,19 @@ class Manager
     void clear();
 
     /**
-     * Return a struct containing information about the device.
+     * Information about the current device.
+     *
+     * @return vk::PhysicalDeviceProperties containing information about the device
      **/
     vk::PhysicalDeviceProperties getDeviceProperties() const;
+
+    /**
+     * List the devices available in the current vulkan instance.
+     *
+     * @return vector of physical devices containing their respective properties
+     **/
+    std::vector<vk::PhysicalDevice> listDevices() const;
+
 
   private:
     // -------------- OPTIONALLY OWNED RESOURCES

--- a/test/TestManager.cpp
+++ b/test/TestManager.cpp
@@ -66,6 +66,14 @@ TEST(TestManager, TestMultipleSequences)
 TEST(TestManager, TestDeviceProperties)
 {
     kp::Manager mgr;
-    const auto properties = mgr.getDeviceProperties();
+    const vk::PhysicalDeviceProperties properties = mgr.getDeviceProperties();
     EXPECT_GT(properties.deviceName.size(), 0);
+}
+
+TEST(TestManager, TestListDevices)
+{
+    kp::Manager mgr;
+    const std::vector<vk::PhysicalDevice> devices = mgr.listDevices();
+    EXPECT_GT(devices.size(), 0);
+    EXPECT_GT(devices[0].getProperties().deviceName.size(), 0);
 }


### PR DESCRIPTION
Fixes #185 

Adds:
* Retrieving physical devices
* Having access to the devices properties
* Python returns dictionary with relevant high level properties
* Added tests in cpp and python
* Fixes issue with CMakelists install interface
* Updates auto to explicit types

In separate PR:
* Allow for listing of devices without creating manager (as static function)
* This will require separating instance creation to static function (and debugCallback)
* Generally having the functions creation vk:: resources as static would be beneficial