### PR TITLE
Updated README and fixed a syntax error on C++'s example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ void kompute(const std::string& shader) {
     kp::Constants pushConstsB({ 3.0 });
 
     auto algorithm = mgr.algorithm(params,
-                                   kp::Shader::compile_source(shader),
+                                   kp::Shader::compileSource(shader),
                                    workgroup,
                                    specConsts,
                                    pushConstsA);

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ void kompute(const std::string& shader) {
         ->eval(); // Evaluates only last recorded operation
 
     // 5. Sync results from the GPU asynchronously
-    sq = mgr.sequence()
+    auto sq = mgr.sequence();
     sq->evalAsync<kp::OpTensorSyncLocal>(params);
 
     // ... Do other work asynchronously whilst GPU finishes
@@ -96,9 +96,9 @@ void kompute(const std::string& shader) {
     sq->evalAwait();
 
     // Prints the first output which is: { 4, 8, 12 }
-    for (const float& elem : tensorOutA->data()) std::cout << elem << "  ";
+    for (const float& elem : tensorOutA->vector()) std::cout << elem << "  ";
     // Prints the second output which is: { 10, 10, 10 }
-    for (const float& elem : tensorOutB->data()) std::cout << elem << "  ";
+    for (const float& elem : tensorOutB->vector()) std::cout << elem << "  ";
 
 } // Manages / releases all CPU and GPU memory resources
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![GitHub](https://img.shields.io/badge/Version-0.7.0-green.svg)
 ![GitHub](https://img.shields.io/badge/C++-14—20-purple.svg)
 ![GitHub](https://img.shields.io/badge/Build-cmake-red.svg)
-![GitHub](https://img.shields.io/badge/Python-3.5—3.8-blue.svg)
+![GitHub](https://img.shields.io/badge/Python-3.5—3.9-blue.svg)
 ![GitHub](https://img.shields.io/badge/License-Apache-black.svg)
 
 <table>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![GitHub](https://img.shields.io/badge/Version-0.5.2-green.svg)
+![GitHub](https://img.shields.io/badge/Version-0.7.0-green.svg)
 ![GitHub](https://img.shields.io/badge/C++-14—20-purple.svg)
 ![GitHub](https://img.shields.io/badge/Build-cmake-red.svg)
 ![GitHub](https://img.shields.io/badge/Python-3.5—3.8-blue.svg)


### PR DESCRIPTION
Updated Vulkan Komputes version from 0.5.2 to 0.7.0
Updated python version from 3.5-3.8 to 3.5-3.8 (works on python 3.9)
Fixed a syntax error on the C++'s example, and in `tensorOutA->data()` changed `data()` to `vector()`