### PR TITLE
Raises an error when having no/exceeding vulkan device's limit

### DIFF
--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -287,6 +287,25 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     }
 
     this->mFreeDevice = true;
+    
+    // Getting an integer that says how many vuklan devices we have
+    uint32_t deviceCount = 0;
+    vkEnumeratePhysicalDevices(*(this->mInstance), &deviceCount, nullptr);
+    
+    // This means there are no devices at all
+    if (deviceCount == 0) {
+    throw std::runtime_error("Failed to find GPUs with Vulkan support! "
+                             "Maybe you haven't installed vulkan drivers?");
+    }
+    
+    // This means that we're exceeding our device limit, for
+    // example if we have 2 devices, just physicalDeviceIndex
+    // 0 and 1 are acceptable. Hence, physicalDeviceIndex should
+    // always be less than deviceCount, else we raise an error
+    if ( !(deviceCount > physicalDeviceIndex) ) {
+    throw std::runtime_error("There is no such physical index or device, "
+                             "please use your existing device");
+    }
 
     std::vector<vk::PhysicalDevice> physicalDevices =
       this->mInstance->enumeratePhysicalDevices();

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -294,8 +294,8 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     
     // This means there are no devices at all
     if (deviceCount == 0) {
-    throw std::runtime_error("Failed to find GPUs with Vulkan support! "
-                             "Maybe you haven't installed vulkan drivers?");
+        throw std::runtime_error("Failed to find GPUs with Vulkan support! "
+                                 "Maybe you haven't installed vulkan drivers?");
     }
     
     // This means that we're exceeding our device limit, for
@@ -303,8 +303,8 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     // 0 and 1 are acceptable. Hence, physicalDeviceIndex should
     // always be less than deviceCount, else we raise an error
     if ( !(deviceCount > physicalDeviceIndex) ) {
-    throw std::runtime_error("There is no such physical index or device, "
-                             "please use your existing device");
+        throw std::runtime_error("There is no such physical index or device, "
+                                 "please use your existing device");
     }
 
     std::vector<vk::PhysicalDevice> physicalDevices =


### PR DESCRIPTION
Currently, if there are no Vulkan devices or if they use a physicalDeviceIndex that is not available(meaning that they exceed their device count), one would get a seg fault.
It would be more plausible if one would get an error with an explanation instead.