### PR TITLE
vkEnumeratePhysicalDevices(*(this->mInstance) ... doesn't work on Linux i386

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,7 +161,9 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             glslang
             SPIRV)
     else()
-        find_package(glslang CONFIG REQUIRED)
+                     
+        find_library(glslang INTERFACE)
+        find_library(SPIRV INTERFACE)
 
         target_include_directories(
             kompute PRIVATE
@@ -171,8 +173,8 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             # Not including hlsl support
             # glslang::HLSL
             # Adding explicit dependencies to match above
-            glslang::glslang
-            glslang::SPIRV)
+            glslang
+            SPIRV)
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,9 +161,7 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             glslang
             SPIRV)
     else()
-                     
-        find_library(glslang INTERFACE)
-        find_library(SPIRV INTERFACE)
+        find_package(glslang CONFIG REQUIRED)
 
         target_include_directories(
             kompute PRIVATE
@@ -173,8 +171,8 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             # Not including hlsl support
             # glslang::HLSL
             # Adding explicit dependencies to match above
-            glslang
-            SPIRV)
+            glslang::glslang
+            glslang::SPIRV)
     endif()
 endif()
 

--- a/src/Manager.cpp
+++ b/src/Manager.cpp
@@ -290,7 +290,7 @@ Manager::createDevice(const std::vector<uint32_t>& familyQueueIndices,
     
     // Getting an integer that says how many vuklan devices we have
     uint32_t deviceCount = 0;
-    vkEnumeratePhysicalDevices(*(this->mInstance), &deviceCount, nullptr);
+    this->mInstance->enumeratePhysicalDevices(&deviceCount, nullptr);
     
     // This means there are no devices at all
     if (deviceCount == 0) {


### PR DESCRIPTION
The code doesn't compile on Linux i386 if `vkEnumeratePhysicalDevices(*(this->mInstance), &deviceCount, nullptr); ` is used(src/Manager.cpp, line 293; I don't know the issue), using `this->mInstance->enumeratePhysicalDevices(&deviceCount, nullptr);` instead solves the problem.
More info:
```cpp
  /project/src/Manager.cpp: In member function ‘void kp::Manager::createDevice(const std::vector<unsigned int>&, uint32_t, const std::vector<std::basic_string<char> >&)’:
  /project/src/Manager.cpp:293:32: error: cannot convert ‘std::__shared_ptr_access<vk::Instance, __gnu_cxx::_S_atomic, false, false>::element_type’ {aka ‘vk::Instance’} to ‘VkInstance’ {aka ‘VkInstance_T*’}
    293 |     vkEnumeratePhysicalDevices(*(this->mInstance), &deviceCount, nullptr);
        |                                ^~~~~~~~~~~~~~~~~~
        |                                |
        |                                std::__shared_ptr_access<vk::Instance, __gnu_cxx::_S_atomic, false, false>::element_type {aka vk::Instance}
```