### PR TITLE
Fixed the issue that caused CMake to look for non-existent path after being installed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,11 +51,23 @@ endif()
 
 target_include_directories(
     kompute PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
-    $<INSTALL_INTERFACE:include>
-    $<INSTALL_INTERFACE:single_include>
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/single_include
 )
+
+# To build the Android example without installing Vulkan Kompute,
+# We need to specify the paths for include directories directly
+# NOTE: This is a temporary fix
+if(KOMPUTE_OPT_ANDOID_BUILD)
+    target_include_directories(
+        kompute PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
+        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:single_include>
+    )
+endif()
+
 
 if(NOT KOMPUTE_OPT_ANDOID_BUILD)
     target_link_libraries(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,19 +55,6 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/single_include
 )
 
-# To build the Android example without installing Vulkan Kompute,
-# We need to specify the paths for include directories directly
-# NOTE: This is a temporary fix
-if(KOMPUTE_OPT_ANDOID_BUILD)
-    target_include_directories(
-        kompute PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/single_include>
-        $<INSTALL_INTERFACE:include>
-        $<INSTALL_INTERFACE:single_include>
-    )
-endif()
-
 
 if(NOT KOMPUTE_OPT_ANDOID_BUILD)
     target_link_libraries(


### PR DESCRIPTION
`$<INSTALL_INTERFACE:single_include>` in `src/CMakeLists.txt` causes CMake to look for a non-existent(#212 ), this PR gets back to the approach that was used before, and also temporarily adding the existent approach to Android because apparently, it faces issues when include directories aren't included explicitly.