### PR TITLE
Adding glslang as a library when using the system's glslang and also a little fix with include dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,8 +51,8 @@ endif()
 
 target_include_directories(
     kompute PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${PROJECT_SOURCE_DIR}/single_include
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,7 +160,7 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             glslang
             SPIRV)
     else()
-        find_package(glslang CONFIG REQUIRED)
+        find_library(glslang INTERFACE)
 
         target_include_directories(
             kompute PRIVATE
@@ -170,8 +170,8 @@ if(NOT KOMPUTE_OPT_DISABLE_SHADER_UTILS)
             # Not including hlsl support
             # glslang::HLSL
             # Adding explicit dependencies to match above
-            glslang::glslang
-            glslang::SPIRV)
+            glslang
+            SPIRV)
     endif()
 endif()
 


### PR DESCRIPTION
As described in  #191 , because glslang doesn't provide a glslangConfig, we have to add it as a library.
Also, in the previous PR I added the wrong path, now it should work.