### PR TITLE
Set PYTHON_INCLUDE_DIR and PYTHON_LIBRARY during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import os
 import re
-import sys
 import platform
+import sys
+import sysconfig
 import subprocess
 
 from setuptools import setup, Extension
@@ -43,7 +44,10 @@ class CMakeBuild(build_ext):
                       '-DKOMPUTE_OPT_BUILD_PYTHON=1',
                       '-DKOMPUTE_OPT_ENABLE_SPDLOG=0',
                       '-DKOMPUTE_OPT_REPO_SUBMODULE_BUILD=1',
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+                      '-DPYTHON_EXECUTABLE=' + sys.executable,
+                      '-DPYTHON_INCLUDE_DIR=' + sysconfig.get_path('include'),
+                      '-DPYTHON_LIBRARY=' + sysconfig.get_path('stdlib'),
+        ]
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
cc @unexploredtest, @axsaucedo, Superchunk. This should fix #221.

# Description
Finding Python for CMake is a known issue. [This PR from PyTorch](https://github.com/pytorch/pytorch/pull/57040/), while not directly related to fixing Python installation issues, shows a tried-and-tested way to help CMake find Python. In particular, the following lines are of interest:

```bash
# Dependencies.cmake
pycmd_no_exit(_py_inc _exitcode "import sysconfig; print(sysconfig.get_path('include'))")
pycmd_no_exit(_py_lib _exitcode "import sysconfig; print(sysconfig.get_path('stdlib'))")
# setup.py
cmake_python_library = "{}/{}".format(
        sysconfig.get_config_var("LIBDIR"),
        sysconfig.get_config_var("INSTSONAME"))
cmake_python_include_dir = sysconfig.get_path("include")
```

I opted for the first option, as the second option gave an incorrect directory on my machine (but the installation still worked).

# Notes
It's worth noting that `FindPython3` (for CMake 3.12+) does a similar thing. See [here](https://cmake.org/cmake/help/v3.20/module/FindPython3.html)