### PR TITLE
Add documentation for CMake flags

### DIFF
--- a/docs/overview/build-system.rst
+++ b/docs/overview/build-system.rst
@@ -72,6 +72,20 @@ Compile Flags
    * - -DKOMPUTE_DISABLE_SHADER_UTILS
      - Disable the shader utils and skip adding glslang as dependency
 
+Other CMake Flags
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Description
+   * - -DPYTHON_INCLUDE_DIR
+     - Path to where Python.h is found, used for specifying installation of Python (see `this PR <https://github.com/EthicalML/vulkan-kompute/pull/222>`_)
+   * - -DPYTHON_LIBRARY
+     - Path to the Python library, used for specifying installation of Python (see `this PR <https://github.com/EthicalML/vulkan-kompute/pull/222>`_)
+   * - -DCMAKE_OSX_ARCHITECTURES
+     - Specifies the target architecture for Apple platforms (see `this issue <https://github.com/EthicalML/vulkan-kompute/issues/223>`_)
 
 Dependencies
 ^^^^^^^^^^^^


### PR DESCRIPTION
cc @axsaucedo.

# Description
This PR adds documentation for:
- #222, which introduced `PYTHON_INCLUDE_DIR` and `PYTHON_LIBRARY`
- #223, which introduced `CMAKE_OSX_ARCHITECTURES`

# Output
<img width="766" alt="Screen Shot 2021-05-30 at 9 03 00 PM" src="https://user-images.githubusercontent.com/37529096/120098516-71926800-c18a-11eb-9748-3f1c48b2e04f.png">

