### PR TITLE
Set kp_debug, kp_info, kp_warning and kp_error to py::none() when the program terminates.

### DIFF
--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -235,6 +235,13 @@ PYBIND11_MODULE(kp, m) {
             return kp::py::vkPropertiesToDict(properties);
         }, "Return a dict containing information about the device");
 
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([](){
+        kp_debug = py::none();
+        kp_info = py::none();
+        kp_warning = py::none();
+        kp_error = py::none();
+    }));
 
 #ifdef VERSION_INFO
     m.attr("__version__") = VERSION_INFO;


### PR DESCRIPTION
cc @unexploredtest, @axsaucedo, Superchunk. This should fix #230.

# Description
The first instance of segfault occurs with a0f9af9, where

```cpp
// main.cpp
- py::object kp_logger;
+ py::object kp_debug, kp_info, kp_warning, kp_error;
```

I suspect that the "attributes" of the `Logger` class (in this case,
```python
kp_debug    = kp_logger.attr("debug");
kp_info     = kp_logger.attr("info");
kp_warning  = kp_logger.attr("warning");
kp_error    = kp_logger.attr("error");
```
) are cleaned up once when the program terminates and then the static global `py::objects` are cleaned up again, leading to segfault.

In [PyTorch](https://github.com/pytorch/pytorch/blob/924717bf5197e075ec6b586c9c4117f5a4fc272b/torch/csrc/distributed/rpc/python_rpc_handler.cpp#L71-L98), there is a similar idea where they use static variables to "cache" `py::object` attributes. Here is a short summary:
```cpp
// python_rpc_handler.cpp
void PythonRpcHandler::init() {
    // ...
    py::object rpcInternal = py::module::import(kInternalModule);   
    // ...
    pyRunFunction_ = getFunction(rpcInternal, "_run_function");    
    pySerialize_ = getFunction(rpcInternal, "serialize");    
    pyDeserialize_ = getFunction(rpcInternal, "deserialize");
}

py::object getFunction(const py::object&amp; module, const char* name) {  
    py::object fn = module.attr(name);  
    TORCH_CHECK(      
              py::isinstance<py::function>(fn),
              "attribute ",   
              name,      
              " is not a function"
    );
    return fn;
}
```

In [this PR from PyTorch](https://github.com/pytorch/pytorch/pull/27251), the fix was to set them to `py:none` during cleanup.

[The pybind docs](https://pybind11.readthedocs.io/en/stable/advanced/misc.html#module-destructors) suggests using the `atexit` for cleanup.

It's unclear why this wasn't an issue in `python3.8` and below.

# Minimal Reproducible Example
- `git clone https://github.com/pybind/python_example`
- Change `src/main.cpp` to
```cpp
#include <pybind11/pybind11.h>

py::object kp_debug;

PYBIND11_MODULE(kp, m) {
    py::module_ logging  = py::module_::import("logging");
    py::object kp_logger = logging.attr("getLogger")("kp");
    kp_debug             = kp_logger.attr("debug");
    /* // Add me to fix!
    auto atexit = py::module_::import("atexit");
    atexit.attr("register")(py::cpp_function([](){
        kp_debug = py::none();
        kp_info = py::none();
        kp_warning = py::none();
        kp_error = py::none();
    }));
    */
}
```
- `python3.9 -m pip install .`
- `python3.9 -c "import kp"`

